### PR TITLE
Fix CI badge in README.md

### DIFF
--- a/Fix CI badge in README.md
+++ b/Fix CI badge in README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/28882168.svg)](https://zenodo.org/badge/latestdoi/28882168)
-[![CI](https://github.com/PHOTOX/ABIN/workflows/GFortran%20CI/badge.svg?branch=master&event=push)](https://github.com/PHOTOX/ABIN/actions?query=workflow%3A%22GFortran+CI%22)
+[![CI](https://github.com/PHOTOX/ABIN/workflows/GFortran%20CI/badge.svg?branch=master)](https://github.com/PHOTOX/ABIN/actions?query=workflow%3A%22GFortran+CI%22)
 
 ----------------
 1. What is ABIN?


### PR DESCRIPTION
Hmm, možná není potřeba, musím ještě pročíst dokumentaci. Zdá se, že už to funguje. Má to vypadat takto:

![image](https://user-images.githubusercontent.com/9539441/95215254-11ad1280-07f1-11eb-90ef-f0dd66a4fa75.png)
