### PR TITLE
Clean compiler warnings and fix FFTW and Plumed compilation

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -90,6 +90,8 @@ jobs:
   # Consider whether this needs to be a separate job
   # or whether it should be default for all builds
   # Here we just take the defaults everywhere, except turning on FFTW
+  # TODO: We actually need to build our own FFTW for different
+  # GFortran versions
   fftw_build:
     # Temporarily disable
     if: false

--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,8 @@ the GNU General Public License, either version 3 of the License,
 or any later version, except for parts noted below.
 A copy of this license is given later in this file. 
 
-Random number generator was kindly provided by prof. M. Lewerenze
-and is provided under GNU GPL v3 license. See random.f90
+The random number generator in random.f90 was kindly provided by prof. M. Lewerenze
+and is distributed under the GNU GPL v3 license. See random.f90
 
 ==============================================================================
 Here is the text of the GPL license:

--- a/abin.F90
+++ b/abin.F90
@@ -24,12 +24,11 @@ program abin_dyn
    use mod_lz, only: lz_hop
    use mod_kinetic, ONLY: temperature
    use mod_utils, only: abinerror, archive_file, get_formatted_date_and_time
-   use mod_shake, only: nshake
    use mod_transform
    use mod_mdstep
    use mod_minimize, only: minimize
    use mod_analysis, only: analysis, restout
-   use mod_interfaces, only: force_clas, force_quantum
+   use mod_interfaces
    use mod_en_restraint
    use mod_plumed
    use mod_terampi_sh, only: move_new2old_terash
@@ -61,7 +60,7 @@ program abin_dyn
 
 !  Surface hopping initialization
    if(ipimd.eq.2.or.ipimd.eq.4)then
-      call sh_init(x, y, z, vx, vy, vz, dt)
+      call sh_init(x, y, z, vx, vy, vz)
    endif
 
 !$ nthreads = omp_get_max_threads()
@@ -246,7 +245,8 @@ program abin_dyn
             cycle
          end if
       
-         call temperature(px,py,pz,amt,dt,eclas)
+         ! TODO: Move this call inside analysis() subroutine
+         call temperature(px, py, pz, amt, eclas)
 
          if(istage.eq.1)then     
 
@@ -254,7 +254,7 @@ program abin_dyn
             call QtoX(x,y,z,transx,transy,transz)
             call FQtoFX(fxc,fyc,fzc,transfxc,transfyc,transfzc)
             call analysis (transx,transy,transz,transxv,transyv,transzv,  &
-                         transfxc,transfyc,transfzc,amt,eclas,equant,dt)
+                         transfxc,transfyc,transfzc,amt,eclas,equant)
 
          else if(inormalmodes.gt.0)then
 
@@ -262,10 +262,10 @@ program abin_dyn
             call UtoX(vx,vy,vz,transxv,transyv,transzv)
             call UtoX(fxc,fyc,fzc,transfxc,transfyc,transfzc)
             call analysis (transx,transy,transz,transxv,transyv,transzv,  &
-                         transfxc,transfyc,transfzc,amt,eclas,equant,dt)
+                         transfxc,transfyc,transfzc,amt,eclas,equant)
          else
       
-            call analysis (x,y,z,vx,vy,vz,fxc,fyc,fzc,amt,eclas,equant,dt)
+            call analysis (x,y,z,vx,vy,vz,fxc,fyc,fzc,amt,eclas,equant)
 
          endif
          

--- a/analysis.F90
+++ b/analysis.F90
@@ -17,7 +17,7 @@ module mod_analysis
    CONTAINS
 
 !  Contains all analysis stuff
-   SUBROUTINE analysis(x,y,z,vx,vy,vz,fxc,fyc,fzc,amt,eclas,equant,dt)
+   SUBROUTINE analysis(x,y,z,vx,vy,vz,fxc,fyc,fzc,amt,eclas,equant)
    use mod_analyze_ext, only: analyze_ext
    use mod_estimators , only: estimators
    use mod_general,     only: it, ipimd, icv,nwrite, nwritef, nwritev, &
@@ -33,15 +33,17 @@ module mod_analysis
    real(DP),intent(inout)    :: vx(:,:),  vy(:,:),  vz(:,:)
    real(DP),intent(in)    :: amt(:,:)
    real(DP),intent(in)    :: eclas, equant
-   real(DP) :: dt  !,energy
+   real(DP) :: energy
 
-!  eclas comes from force_clas,equant from force_quantum
-!  energy=eclas+equant
+   ! eclas is the ab initio energy averaged per bead,
+   ! equant is additional harmonic energy between PI beads (from force_quantum)
+   ! TODO: Print equant or energy somewhere
+   energy = eclas + equant
 
    if(modulo(it,nwrite).eq.0.and.idebug.gt.0) call remove_rotations(x, y, z, vx, vy, vz, am, .false.)
 
    if (ipimd.eq.1.or.icv.eq.1)then
-      call estimators(x, y, z, fxc, fyc, fzc, eclas, dt)
+      call estimators(x, y, z, fxc, fyc, fzc, eclas)
    endif
 
    if(modulo(it,nwritex).eq.0)then
@@ -146,7 +148,12 @@ module mod_analysis
    fgeom='(A2,3E18.10E2)'
    fkom='(A10,3E13.5E2,A14,3E13.5E2)'
 
-   write(funit,*)natom
+   ! TODO: Include somehow the timestep in the output
+   ! Either here:
+   ! write(funit, *)natom, it
+   ! or maybe better here
+   ! write(funit,fkom)'time step', it, 'net force:',fx_tot,fy_tot,fz_tot,' torque force:',fx_rot,fy_rot,fz_rot
+   write(funit, *)natom
    write(funit,fkom)'net force:',fx_tot,fy_tot,fz_tot,' torque force:',fx_rot,fy_rot,fz_rot
    do iw=1,nwalk
       do iat=1,natom

--- a/analyze_ext_2dho.f90
+++ b/analyze_ext_2dho.f90
@@ -1,4 +1,3 @@
-!---This is a template file for user-defined analysis function.
 !---This function will be called if anal_ext=1 in input(section general).
 !---Should the user need something more then coordinates(velocities,forces),
 ! he/she must also modify  analysis.f90 and possibly abin.f90

--- a/analyze_ext_template.f90
+++ b/analyze_ext_template.f90
@@ -10,12 +10,11 @@ module mod_analyze_ext
 
    subroutine analyze_ext(x,y,z,vx,vy,vz,amt)
    use mod_general, only: it
-   real(DP) x(:,:),y(:,:),z(:,:)
-   real(DP) vx(:,:),vy(:,:),vz(:,:)
-   real(DP) amt(:,:)
-   character(len=100)   :: chsystem
-   character(len=50)   :: chit
-
+   real(DP), intent(in) :: x(:,:),y(:,:),z(:,:)
+   real(DP), intent(in) :: vx(:,:),vy(:,:),vz(:,:)
+   real(DP), intent(in) :: amt(:,:)
+   character(len=100) :: chsystem
+   character(len=50) :: chit
 
    ! Launch external BASH script.
    ! Can be used to analyze wavefunction on-the-fly
@@ -23,12 +22,6 @@ module mod_analyze_ext
    chsystem='./analyze_ext.sh '//trim(chit)
    call system(chsystem)
 
-!   if(modulo(it,nwrite).eq.0)then
-!--print output every nwrite steps              
-!   endif
-   
    end subroutine analyze_ext
 
 end module
-                                        
-

--- a/configure
+++ b/configure
@@ -29,7 +29,7 @@ NAME
    configure - generate local configuration for ABIN
 
 SYNOPSIS
-   configure [--debug] [--mpi path/to/mpi] [--plumed path/to/plumed] [--pfunit path/to/pfunit] [--cp2k]
+   configure [--debug] [--mpi path/to/mpi] [--plumed path/to/plumed/lib] [--pfunit path/to/pfunit] [--cp2k]
 
 OPTIONS
    --debug       Compile in debug mode
@@ -109,7 +109,7 @@ done
 
 # Set to default if FFLAGS is not defined yet, see
 # https://stackoverflow.com/questions/11362250/in-bash-how-do-i-test-if-a-variable-is-defined-in-u-mode
-: ${FFLAGS:='-O2 -fopenmp'}
+: ${FFLAGS:='-O2 -fopenmp -Wall'}
 
 if [[ -z ${FC-} ]];then
    if [[ $MPI = "TRUE" ]];then
@@ -135,8 +135,8 @@ CXX="c++"
 CXXFLAGS="-O2 -Wall -std=c++11"
 
 if [[ $PLUMED = "TRUE" ]];then
-   if [[ ! -f $PLUMED_PATH/Plumed.inc ]];then
-      echo "File $PLUMED_PATH/Plumed.inc does not exist!"
+   if [[ ! -f $PLUMED_PATH/lib/Plumed.inc ]];then
+      echo "File $PLUMED_PATH/lib/Plumed.inc does not exist!"
       exit 1
    fi
 fi
@@ -169,7 +169,7 @@ MPI_PATH = $MPI_PATH
 
 # Compilation with Plumed library
 PLUMED = $PLUMED
-PLUMED_LINK = $PLUMED_PATH/Plumed.inc
+PLUMED_INC = $PLUMED_PATH/lib/Plumed.inc
 
 # FFTW library is typically shipped with your system
 # It is needed for normal mode coordinate transformation in PIMD

--- a/density.f90
+++ b/density.f90
@@ -25,7 +25,7 @@ module mod_density
    end subroutine dist_init
 
    subroutine density(x,y,z)
-   use mod_general,  only: it, nwalk, nwrite, pot,natom
+   use mod_general,  only: it, nwalk, nwrite
    use mod_system,   only: dime
    use mod_utils,    only: get_distance, abinerror
    real(DP),intent(in)  :: x(:,:),y(:,:),z(:,:)

--- a/ekin.f90
+++ b/ekin.f90
@@ -9,7 +9,7 @@ module mod_kinetic
    real(DP) :: est_temp_cumul=0.0d0,entot_cumul=0.0d0
    save
    contains
-   subroutine temperature(px,py,pz,amt,dt,eclas)
+   subroutine temperature(px, py, pz, amt, eclas)
       use mod_const, ONLY:AUtoFS,AUtoK
       use mod_general
       use mod_system,ONLY: dime, f, conatom
@@ -21,7 +21,7 @@ module mod_kinetic
       integer :: iw,iat
       real(DP),intent(in)  :: px(:,:),py(:,:),pz(:,:)
       real(DP),intent(in)  :: amt(:,:)
-      real(DP),intent(in)  :: dt,eclas
+      real(DP),intent(in)  :: eclas
       real(DP)  :: est_temp,temp1,ekin_mom
       real(DP)  :: it2
       

--- a/en_restraint.F90
+++ b/en_restraint.F90
@@ -20,10 +20,9 @@ CONTAINS
 
 ! B) Quadratic potential around target value (en_kk must be set)
 
-subroutine en_rest_init(dt)
+subroutine en_rest_init()
    use mod_general,  only: natom
    implicit none
-   real(DP),intent(in) :: dt
 
    allocate(fxr(natom,2)) ! two states, not beads.
    allocate(fyr(natom,2))
@@ -31,14 +30,16 @@ subroutine en_rest_init(dt)
 end subroutine en_rest_init
 
 subroutine energy_restraint(x, y, z, px, py, pz, eclas)
-   use mod_general,  only: natom, it, dt0 ! dt0 is the time step
+   use mod_general,  only: natom, dt0 ! dt0 is the time step
    use mod_utils,    only: abinerror
    use mod_const,    only: AMU
    use mod_system,   only: am
    use mod_sh,       only: en_array
    use mod_terampi_sh, only: force_terash
    implicit none
-   real(DP),intent(inout)  :: x(:,:),y(:,:),z(:,:),eclas
+   real(DP),intent(inout)  :: x(:,:),y(:,:),z(:,:)
+   ! TODO: Eclas is not modified in this routine, but probably should be
+   real(DP),intent(inout)  :: eclas
    real(DP),intent(inout)  :: px(:,:),py(:,:),pz(:,:)
    ! DH: I am surprised this works, since natom is not a constant
    real(DP),dimension(natom):: fxgs,fygs,fzgs,fxes,fyes,fzes
@@ -48,7 +49,6 @@ subroutine energy_restraint(x, y, z, px, py, pz, eclas)
 
 do iw=1,nwalk
 
-   ! DH call the extra forces and potentials here
    if(restrain_pot.eq.'_tera_')then
       call force_terash(x, y, z, fxr, fyr, fzr, eclasground)
       do iat=1,natom
@@ -73,8 +73,8 @@ do iw=1,nwalk
 !-----READING energy of groud state (engrad.ground.dat)
     open(901,file=chforce_ground,status='OLD',iostat=ios,action='read')
     if (ios.ne.0)then
-       write(*,*)'Error: could not read engrad.ground.dat.001! Check if you use proper &
-       external script for restrained energy dynamics.'
+       write(*,*)'Error: could not read ' // chforce_ground
+       write(*,*)'Check whether you use proper external script for restrained energy dynamics.'
        call abinerror('energy_restraint')
     end if
     read(901,*) eclasground

--- a/estimators.f90
+++ b/estimators.f90
@@ -14,15 +14,15 @@ module mod_estimators
    save
    CONTAINS
 !--Expecting cartesian coordinates and forces!
-   subroutine estimators(x, y, z, fxab, fyab, fzab, eclas, dt)
-   use mod_general
+   subroutine estimators(x, y, z, fxab, fyab, fzab, eclas)
+   use mod_general, only: pot, natom, nwalk, it, sim_time, ncalc, nwrite, inormalmodes, imini, ihess, icv
    use mod_nhc, ONLY:temp, inose
    use mod_system, ONLY:am, dime
    use mod_harmon, ONLY:hess_harmon, hess_morse, hess_2dho, hess
    use mod_shake, only: nshake
    real(DP),intent(inout) :: x(:,:),y(:,:),z(:,:)
    real(DP),intent(in) :: fxab(:,:),fyab(:,:),fzab(:,:)
-   real(DP),intent(in) :: dt,eclas
+   real(DP),intent(in) :: eclas
    real(DP)  :: xc(size(x,1)), yc(size(x,1)), zc(size(x,1))
    real(DP)  :: cvhess( size(x,2) ), dc( size(x,1)*3, size(x,2) )
    real(DP)  :: est_vir,est_prim,cv_prim,cv_vir,cv_dcv
@@ -204,11 +204,6 @@ module mod_estimators
 
       if(icv.eq.1.and.enmini.lt.it)then
          write(UCV,'(F15.2,4E20.10)')sim_time*AUtoFS,cv_prim,cv_vir,cv_prim_cumul/it2,cv_vir_cumul/it2
-
-!       CV_PCV estimator is not correctly implemented at the moment        
-!       open(126,file='cv_pcv.dat',access='append')
-!       write(126,*)it*dt,cv_pcv
-!       close(126)
 
          if(ihess.eq.1)then
             write(UCVDCV,'(F15.2,2E20.10)')sim_time*AUtoFS,cv_dcv,cv_dcv_cumul/it2

--- a/fftw_interface.F90
+++ b/fftw_interface.F90
@@ -1,9 +1,15 @@
-
+! Interface to FFTW library for Fast Fourier Transform
+! Currently utilized for normal mode transformation in Path Integral simulations
 module mod_fftw3
    use, intrinsic :: iso_c_binding
    private
 #ifdef USE_FFTW
-   public :: fftw_init, fftw_end
+   public :: fftw_init, fftw_end, plan_utox, plan_xtou
+   ! TODO: Not sure that these arrays should be public and live here,
+   ! They should probably we allocated where they are used in transform.F90
+   public :: x_in, y_in, z_in, cx, cy, cz
+   public :: fftw_execute_dft_r2c, fftw_execute_dft_c2r 
+   ! TODO: Is there a better way to do this in newer FFTW versions?
    include 'fftw3.f90'
    type(C_PTR) :: plan_utox,plan_xtou
    real(C_DOUBLE), dimension(:), allocatable :: x_in, y_in, z_in
@@ -11,6 +17,8 @@ module mod_fftw3
    save
    contains
 
+   ! TODO: This should be named more specifically, maybe
+   ! fftw_normalmodes_init()
    subroutine fftw_init(nwalk)
       use mod_const, only: DP
       use mod_utils, only: abinerror

--- a/force_abin.f90
+++ b/force_abin.f90
@@ -5,7 +5,7 @@ subroutine force_abin(x, y, z, fx, fy, fz, eclas, chpot, walkmax)
    use mod_system,   only: names
    use mod_harmon,   only: hess
    use mod_sh_integ, only: nstate
-   use mod_sh,       only: nac_accu1, tocalc, en_array, istate
+   use mod_sh,       only: tocalc, en_array, istate
    use mod_lz,       only: nstate_lz, tocalc_lz, en_array_lz, istate_lz, nsinglet_lz, ntriplet_lz
    use mod_qmmm,     only: natqm
    use mod_utils,    only: abinerror, lowertoupper

--- a/force_cp2k.F90
+++ b/force_cp2k.F90
@@ -158,7 +158,7 @@ end subroutine finalize_cp2k
 #endif
 
 subroutine force_cp2k(x, y, z, fx, fy, fz, eclas, walkmax)
-   use mod_general,  only: natom, iqmmm, idebug, my_rank,mpi_world_size, nwalk
+   use mod_general,  only: natom, iqmmm, idebug, my_rank, mpi_world_size, nwalk
    use mod_utils,    only: abinerror
    use mod_interfaces, only: oniom
    use mod_utils,    only: abinerror

--- a/fortran_interfaces.f90
+++ b/fortran_interfaces.f90
@@ -4,10 +4,9 @@ module mod_interfaces
    use mod_const, only: DP
    INTERFACE
 
-   subroutine init(dt, values1)
+   subroutine init(dt)
    IMPORT :: DP
    real(DP),intent(out) :: dt
-   integer,dimension(8) :: values1
    end subroutine init
 
    subroutine print_compile_info()

--- a/gle.F90
+++ b/gle.F90
@@ -29,7 +29,6 @@ module mod_gle
    real(DP)         :: langham
    integer          :: ns, ns_centroid, readQT=1
    real(DP), allocatable :: c1(:), c2(:)
-   integer  :: iglobal = 0
    save
 
 contains
@@ -87,7 +86,7 @@ contains
    integer :: iat, iw, pom
 
    pom=1
-   call gautrg(ran,natom*3*nwalk,0,6)
+   call gautrg(ran, natom * 3 * nwalk)
 
    ! This is a local version of the thermostat (PILE-L)
    ! TODO: implement global version according to equations 51-54
@@ -109,7 +108,7 @@ contains
   
    subroutine gle_init(dt)
    use mod_const, only: AUtoEV
-   use mod_general,only: natom, nwalk, inormalmodes, my_rank, iremd, irest
+   use mod_general,only: natom, nwalk, inormalmodes, my_rank, iremd
    use mod_utils, only: abinerror
    use mod_nhc,only: temp,inose
    implicit none
@@ -287,7 +286,7 @@ contains
    end subroutine gle_init
 
    subroutine initialize_momenta(C, iw)
-   use mod_arrays,  only: px, py, pz
+   !use mod_arrays,  only: px, py, pz
    use mod_general, only: natom
    use mod_utils,   only: abinerror
    real(DP), intent(in) :: C(:,:)
@@ -296,14 +295,14 @@ contains
    integer  :: i, j
    ! WARNING: this routine must be called after arrays are allocated!
    if(.not.allocated(ps))then
-      write(*,*)"WHOOOPS: Fatal programming error int gle.F90!!"
+      write(*,*)"WHOOOPS: Fatal programming error in gle.F90!"
       call abinerror("initialize_momenta")
    end if
 
    allocate(gr(ns+1))
 
    do j=1,natom*3
-      call gautrg(gr,ns+1,0,6)
+      call gautrg(gr, ns + 1)
       ! TODO, actually pass this to initialize momenta
       gp(j,:) = matmul(C, gr)
    end do
@@ -404,7 +403,7 @@ contains
 
 
    subroutine gle_propagate(p, T, S, mass, iw)
-   use mod_general, only: natom, inormalmodes
+   use mod_general, only: natom
    real(DP), intent(inout) :: p(:,:)
    real(DP), intent(in) :: T(:,:), S(:,:), mass(:,:)
    real(DP)  :: sqm
@@ -422,7 +421,7 @@ contains
    ! now, must compute random part. 
    ! first, fill up p of random n
    do i=1,ns+1
-      call gautrg(ran,natom*3,0,6)
+      call gautrg(ran, natom*3)
       do j=1,natom
          sqm = sqrt( mass(j,iw) )
          !<-- if m!= 1, alternatively one could perform the scaling here (check also init!)

--- a/io.F90
+++ b/io.F90
@@ -10,20 +10,18 @@ module mod_io
 
    subroutine print_charges(charges, iw_ist)
    use mod_files, only: UCHARGES
-   use mod_general, only: nwalk, natom, it
-   use mod_system, only: names
+   use mod_general, only: natom, it
    use mod_const, only: DP
    integer, intent(in)  :: iw_ist
    real(KIND=DP),intent(in) :: charges(:)
    integer :: iat
 
-   write(UCHARGES, format5, advance='no')it,iw_ist
+   write(UCHARGES, format5, advance='no')it, iw_ist
    do iat=1,natom
       write(UCHARGES,format4, advance='no')charges(iat)
    enddo
 
    write(UCHARGES,*)
-
    end subroutine print_charges
 
    subroutine print_dipoles(dipoles, iw, nstates)
@@ -34,7 +32,7 @@ module mod_io
    real(KIND=DP) :: total_dip
    integer :: ind
 
-   write(UDIP,format1,advance='no')it
+   write(UDIP,format1,advance='no')it, iw
 
    do ind=1,3*nstates,3
       total_dip = dipoles(ind)**2 + dipoles(ind+1)**2 + dipoles(ind+2)**2
@@ -51,7 +49,7 @@ module mod_io
 
    subroutine print_transdipoles(tdipoles, istate, ntdip)
    use mod_files,  only: UTDIP
-   use mod_general,only: nwalk, natom, it
+   use mod_general,only: it
    integer, intent(in)  :: istate, ntdip
    real(KIND=DP),intent(in) :: tdipoles(:)
    real(KIND=DP) :: total_tdip

--- a/landau_zener.F90
+++ b/landau_zener.F90
@@ -141,7 +141,7 @@ module mod_lz
 
    !Hop?
    ihop=0
-   call vranf(ran,1,0,6)
+   call vranf(ran, 1)
    hop_rdnum = ran(1)
 
    ! Determine, whether we hopped or not
@@ -156,7 +156,7 @@ module mod_lz
    end do 
 
    ! Determine on which state (weighted sampling of all probable hops)
-   call vranf(ran,1,0,6)
+   call vranf(ran, 1)
    hop_rdnum2 = ran(1)
    do ist1=ibeg, iend
       if (ist1.eq.ist) cycle
@@ -246,7 +246,7 @@ module mod_lz
 
      Ekin = ekin_v(vx,vy,vz)
      molveloc = sqrt(2.0d0*Ekin/sum(am(1:natom)))
-     call vranf(ran,1,0,6)
+     call vranf(ran,1)
      hop_rdnum = ran(1)
      icross=0
 

--- a/mdstep.f90
+++ b/mdstep.f90
@@ -24,7 +24,6 @@ module mod_mdstep
 
 
    subroutine shiftP (px, py, pz, fx, fy, fz, dt)
-   use mod_general, only: nwalk, natom
    use mod_system,  only: conatom
    use mod_vinit,   only: constrainP
    real(DP),intent(inout)  :: px(:,:), py(:,:), pz(:,:)
@@ -84,7 +83,8 @@ module mod_mdstep
    use mod_general, ONLY: pot, ipimd, inormalmodes, en_restraint
    use mod_nhc, ONLY:inose
    use mod_interfaces, only: force_clas, propagate_nm
-   use mod_sh, only: ehrenfest_forces
+   ! Not yet implemented
+   !use mod_sh, only: ehrenfest_forces
    use mod_en_restraint
    real(DP),intent(inout) :: x(:,:), y(:,:), z(:,:)
    real(DP),intent(inout) :: fxc(:,:), fyc(:,:), fzc(:,:)
@@ -112,7 +112,7 @@ module mod_mdstep
       ! This is only a stub for now
       write(*,*)'ERROR: Ehrenfest MD not implemented yet!!'
       call abinerror('verletstep')
-      call ehrenfest_forces(x, y, z, fxc, fyc, fzc, px, py, pz, dt, eclas)
+      !call ehrenfest_forces(x, y, z, fxc, fyc, fzc, px, py, pz, dt, eclas)
    end if
 
    call shiftP (px, py, pz, fxc, fyc, fzc, dt/2)

--- a/modules.f90
+++ b/modules.f90
@@ -139,29 +139,28 @@ module mod_system
    CONTAINS
 
    ! We should loop over this function over different beads
-   subroutine read_properties(traj_prop)
-   use mod_general, only: nwalk, natom
-   type(Traj_Properties), intent(out) :: traj_prop(:)
-   integer :: iw
+   !subroutine read_properties(traj_prop)
+   ! use mod_general, only: nwalk, natom
+   !type(Traj_Properties), intent(inout) :: traj_prop(:)
+   !integer :: iw
 
    ! we should make some generalized reading function in utils
    ! i.e. dipole moments and transition dipolo moments can reuse
    ! (e.g. simply read..) but where should we open the unit? 
    ! but maybe not, these things might be rather different?
 
-   do iw = 1, nwalk
+   !do iw = 1, nwalk
 
-   end do
+   !end do
 
-   end subroutine read_properties
+   !end subroutine read_properties
 
-   subroutine write_properties(traj_prop)
-   type(Traj_Properties), intent(out) :: traj_prop
+   !subroutine write_properties(traj_prop)
+   !type(Traj_Properties), intent(inout) :: traj_prop
 
    ! should introduce nwriteprop
    ! by default should equal nwritex
-
-   end subroutine write_properties
+   !end subroutine write_properties
 
    subroutine clean_prop_tempfiles
 

--- a/nosehoover.F90
+++ b/nosehoover.F90
@@ -149,7 +149,7 @@ module mod_nhc
    if(initNHC.eq.1.and.imasst.eq.1)then
       do inh=1,nchain
          do iw=1,nwalk
-            call gautrg(ran,natom*3,0,6)
+            call gautrg(ran, natom * 3)
             ipom=1
             do iat=1,natom 
                pnhx(iat,iw,inh) = ran(ipom)   * sqrt(temp*Qm(iw))
@@ -165,7 +165,7 @@ module mod_nhc
       do inh=1,nchain
          do iw=1,nwalk
             ! +1 if nmolt=1, gautrg needs array at least of length=2
-            call gautrg(ran,nmolt+1,0,6)
+            call gautrg(ran, nmolt + 1)
             do imol=1,nmolt 
                pnhx(imol,iw,inh)=ran(imol)*sqrt(temp*ms(imol,inh))
             enddo

--- a/potentials.f90
+++ b/potentials.f90
@@ -1,15 +1,15 @@
 !  Various analytical potentials
 !  Now including harmonic potential for diatomic molecule, 3D-harmonic and Morse
 !  For all these, hessian is also available.
-!  Now also includes double-well potential, originaly used for testing PLUMED.
-!  
-!  Parameters should be set in input section system
 
-!------------------------------------------------------
-!     some constansts for analytical potentials      
+!  Includes double-well potential, originaly used for testing PLUMED.
+!  
+!  Parameters should be set in input section 'system'
+
 module mod_harmon
    use mod_const, only: DP
    implicit none
+!--some constansts for analytical potentials      
 !--constants for 3DHO
    real(DP) :: k1=0.0d0,k2=0.0d0,k3=0.0d0
 !--constants for 1D 2-particle harmonic oscillator
@@ -24,6 +24,7 @@ module mod_harmon
    CONTAINS
 
 !------3D Harmonic Oscillator---only 1 particle!!
+   ! TODO: Rename this function to force_harmonic_oscillator()
    subroutine force_2dho(x,y,z,fxab,fyab,fzab,eclas)
       use mod_general, only: nwalk
       real(DP),intent(in)  :: x(:,:),y(:,:),z(:,:)
@@ -47,11 +48,12 @@ module mod_harmon
       return
    end subroutine force_2dho
       
-!oooooooo DOUBLE WELL potential -- ref. Tuckerman, Statistical Mechanics,p350 --oooooooooooooooo
-  subroutine  force_doublewell(x,y,z,fxab,fyab,fzab,eclas)
+  ! 2D DOUBLE WELL potential
+  ! According to: Tuckerman, Statistical Mechanics, page 350
+  subroutine  force_doublewell(x,y,fxab,fyab,eclas)
       use mod_general, only: nwalk
-      real(DP),intent(in)  :: x(:,:),y(:,:),z(:,:)
-      real(DP),intent(out) :: fxab(:,:),fyab(:,:),fzab(:,:)
+      real(DP),intent(in)  :: x(:,:), y(:,:)
+      real(DP),intent(out) :: fxab(:,:), fyab(:,:)
       real(DP),intent(out) :: eclas
       integer              :: i
 
@@ -60,7 +62,6 @@ module mod_harmon
       do i=1,nwalk
          fxab(1,i) = -4*D0_dw*x(1,i) * (x(1,i)**2-r0_dw**2) - lambda_dw*y(1,i)
          fyab(1,i) = -k_dw * y(1,i) - lambda_dw*x(1,i)
-         fzab(1,i) = 0
          eclas = eclas + D0_dw*(x(1,i)**2-r0_dw**2)**2 + &
             0.5*k_dw*y(1,i)**2 + lambda_dw*x(1,i)*y(1,i)
       enddo
@@ -71,6 +72,7 @@ module mod_harmon
 
 
 !ccccccccHARMONIC OSCILLATOR--diatomic molecules--ccccccccccccccccccccc
+   ! TODO: Rename this, name should be distiguishable from force_2dho
    subroutine force_harmon(x,y,z,fxab,fyab,fzab,eclas)
       use mod_general, only: nwalk
       real(DP),intent(in)  :: x(:,:),y(:,:),z(:,:)
@@ -265,6 +267,7 @@ module mod_harmon
 end module mod_harmon
 
 
+! 1D numerical potential with cubic splines
 module mod_splined_grid
    use mod_const, only: DP
    implicit none
@@ -287,17 +290,18 @@ CONTAINS
       return
    end function potential_cubic_spline
 
-   subroutine force_splined_grid(x, y, z, fx, fy, fz, eclas)
+   ! TODO: Remove y and z components from arguments, since we 
+   ! only support 1D spline at the moment
+   subroutine force_splined_grid(x, fx, eclas)
       use mod_general,  only: nwalk
       use mod_utils,    only: abinerror
-      real(DP),intent(in)  :: x(:,:),y(:,:),z(:,:)
-      real(DP),intent(out) :: fx(:,:),fy(:,:),fz(:,:)
+      real(DP),intent(in)  :: x(:,:)
+      real(DP),intent(out) :: fx(:,:)
       real(DP),intent(out) :: eclas
       real(DP) :: en_1, en_2, dx = 0.0001d0
-!      real(DP) :: potential_cubic_spline
       integer  :: iw
 
-      fy = 0.0d0; fz = 0.0d0; eclas = 0.0d0
+      eclas = 0.0d0
       do iw = 1, nwalk
 
          if(x(1, iw).lt.x_min.or.x(1, iw).gt.x_max)then

--- a/qmmm.F90
+++ b/qmmm.F90
@@ -7,5 +7,7 @@ module mod_qmmm
    public :: natqm, natmm
    integer :: natqm, natmm
    ! NOT used anywhere at the moment
-   character(len=10)    :: qmmmtype='NA'
+   !character(len=10)    :: qmmmtype='NA'
+   ! Maybe move iqmmm here
+   ! TODO: Move ONIOM here
 end module mod_qmmm

--- a/read_cmdline.F90
+++ b/read_cmdline.F90
@@ -26,11 +26,10 @@ module mod_cmdline
 
 
    subroutine get_cmdline(chinput, chcoords, chveloc, tc_port)
-      use mod_utils, only: abinerror, file_exists_or_exit
+   use mod_utils, only: abinerror, file_exists_or_exit
    character(len=*),intent(inout) :: chinput, chcoords, chveloc, tc_port
    character(len=len(chinput)) :: arg
    integer :: i
-   logical :: lexist
    
    i = 0
    do while (i < command_argument_count())

--- a/remd.F90
+++ b/remd.F90
@@ -18,7 +18,6 @@ CONTAINS
    !TODO: make general subroutine check_mpi_error in utils.f90 and check every ierr
    subroutine remd_swap(x, y, z, px, py, pz, fxc, fyc, fzc, eclas)
    use mod_general, only: my_rank, it
-   use mod_nhc,     only: temp
    use mod_random,  only: vranf
    real(DP),intent(inout)   ::  x(:,:), y(:,:), z(:,:)
    real(DP),intent(inout)   ::  px(:,:), py(:,:), pz(:,:)
@@ -31,7 +30,7 @@ CONTAINS
 
 
    ! Broadcast array of random numbers from rank 0 
-   if (my_rank.eq.0) call vranf(ran, nreplica-1, 0, 6)
+   if (my_rank.eq.0) call vranf(ran, nreplica - 1)
 
    ! TODO: This is probably no longer needed, each mpi rank has now
    ! "independent" prngs...
@@ -101,7 +100,6 @@ CONTAINS
 
    subroutine swap_replicas(x, y, z, px, py, pz, fxc, fyc, fzc, rank1, rank2)
    use mod_general, only: my_rank 
-   use mod_nhc,     only: temp
    real(DP),intent(inout)  ::  x(:,:), y(:,:), z(:,:)
    real(DP),intent(inout)  ::  px(:,:), py(:,:), pz(:,:)
    real(DP),intent(inout)  ::  fxc(:,:), fyc(:,:), fzc(:,:)

--- a/shake.F90
+++ b/shake.F90
@@ -32,7 +32,7 @@ module mod_shake
       ! Or determine bonds in a better way
       hbond_len_thr = 2.0 * ANG
       ! Here we assume that each H atom has a single bond
-      num_shake = count_atoms('H')
+      num_shake = count_atoms_by_name('H')
       ! TODO: Not sure about this, but shake does not 
       ! work with PIMD anyway at this point
       iw = 1
@@ -78,18 +78,19 @@ module mod_shake
 
    end subroutine find_hbonds
 
-   real(DP) function count_atoms(atom_name)
+   ! TODO: Maybe move this to utils
+   integer function count_atoms_by_name(atom_name)
       use mod_general, only: natom
       use mod_system, only: names
       character(len=*), intent(in) :: atom_name
       integer :: nat, iat
       nat = 0
       do iat = 1, natom
-        if (names(iat).eq.atom_name) nat = nat +1
+        if (names(iat).eq.atom_name) nat = nat + 1
       end do
-      count_atoms = nat
+      count_atoms_by_name = nat
       return
-   end function count_atoms
+   end function count_atoms_by_name
 
 
    subroutine shake_init(x,y,z)

--- a/transform.F90
+++ b/transform.F90
@@ -87,7 +87,7 @@ module mod_transform
    use mod_system, ONLY: am
    real(DP),intent(out) :: amg(:,:), amt(:,:)
    real(DP)  :: lambda(size(amg,2)+1) !amg(natom,nwalk) - why +1?
-   integer :: iat, iw, k, nmodes, odd
+   integer :: iat, iw, nmodes, odd
 
 !  NOTE: am was multiplied by amu earlier in the init.F90
 
@@ -314,7 +314,7 @@ module mod_transform
    real(DP) :: x(:,:), y(:,:), z(:,:)
    real(DP) :: transx(:,:), transy(:,:), transz(:,:)
    integer  :: iat, iw
-   real(DP) :: dnwalk, equant, fac
+   real(DP) :: dnwalk, fac
    integer  :: nmodes, odd
 
    if(inormalmodes.eq.1)then
@@ -367,8 +367,6 @@ endif
    transx = transx / dnwalk
    transy = transy / dnwalk
    transz = transz / dnwalk
-
-!   call equant_nm(transx, transy, transz, equant)
 
 !  write(*,*)'original cartesian to normal modes'
 !  call print_xyz_arrays(x/ang,y/ang,z/ang)

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -14,15 +14,13 @@ ifneq ($(strip $(PFUNIT_PATH)),)
   FFLAGS = $(PFUNIT_EXTRA_FFLAGS)
   FFLAGS += -I../
 endif
- 
-STATIC_LIBS = ../libabin.a ../WATERMODELS/libwater.a
 
-LDLIBS = -lm -lstdc++ ${LIBS}
+# NOTE: $(LIBS) are defined in the root Makefile
 
 utils_TESTS := test_utils.pf
 utils_REGISTRY :=
 utils_OTHER_SOURCES :=
-utils_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../" -labin -L"../WATERMODELS/" -lwater $(LDLIBS)
+utils_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../" -labin -L"../WATERMODELS/" -lwater ${LIBS}
 utils_OTHER_INCS :=
 
 $(eval $(call make_pfunit_test,utils))

--- a/vinit.f90
+++ b/vinit.f90
@@ -32,7 +32,7 @@ module mod_vinit
 !
 !------------------------------------------------------------------------
 SUBROUTINE vinit(TEMP, MASS, vx, vy, vz)
-   USE mod_general,  ONLY: natom, pot, nwalk, my_rank
+   USE mod_general,  ONLY: natom, pot, nwalk
    USE mod_random,   ONLY: gautrg
    real(DP),intent(out)    :: vx(:,:), vy(:,:), vz(:,:)
    real(DP),intent(in)     :: mass(:)
@@ -42,7 +42,7 @@ SUBROUTINE vinit(TEMP, MASS, vx, vy, vz)
 
    do iw=1,nwalk
 
-      call gautrg(rans,natom*3,0,6)  
+      call gautrg(rans, natom*3)
 
       pom=1
       do iat=1,natom
@@ -156,7 +156,7 @@ END SUBROUTINE remove_comvel
 
 subroutine remove_rotations(x, y, z, vx, vy, vz, masses, lremove)
    use mod_system,      only: dime
-   use mod_general,     only: natom, nwalk, my_rank, pot
+   use mod_general,     only: natom, nwalk, my_rank
    real(DP),intent(in)     :: x(:,:), y(:,:), z(:,:)
    real(DP),intent(inout)  :: vx(:,:), vy(:,:), vz(:,:)
    real(DP),intent(in)     :: masses(:)
@@ -291,7 +291,7 @@ END SUBROUTINE REMOVE_ROTATIONS
       real(DP),intent(inout) :: px(:,:),py(:,:),pz(:,:)
       integer, intent(in) :: constrained_atoms
       integer :: iw,iat
-!     if (my_rank.eq.0) write(*,*)'Removing momentum of constrained atoms.'
+      if (my_rank.eq.0) write(*,*)'Removing momentum of constrained atoms.'
       do iw = 1, nwalk
          do iat = 1, constrained_atoms
             px(iat,iw) = 0.0d0

--- a/water.f90
+++ b/water.f90
@@ -33,6 +33,8 @@ module mod_water
    end if
 
    if (watpot.lt.1.or.watpot.gt.4)then
+      ! TODO: Print out what the various option means!
+      ! (different water force fields)
       write(*,*)'Error: parameter watpot must be 0,1,2,3 or 4.'
       call abinerror('check_water')
    end if


### PR DESCRIPTION
This is mostly removing unused variables. 

Also, previous changes broke the FFTW build.
Plumed build was not broken, but compiling unit tests with Plumed did not work. Now it does.

I also simplified the interface to PRGN a little bit.