### PR TITLE
Fix -shiftdih option in analyze_movie

### DIFF
--- a/UTILS/analyze_movie.f90
+++ b/UTILS/analyze_movie.f90
@@ -260,8 +260,8 @@ allocate( z(natom) )
 allocate( names(natom) )
 
 
-dihmin=dihmin+shiftdih
-dihmax=dihmax+shiftdih
+dihmin = dihmin + shiftdih/2
+dihmax = dihmax + shiftdih/2
 
 if (ndist.gt.0.and.imod.ne.1 ) open(101,file="dist_time.dat")
 if (nang.gt.0 )  open(102,file="ang_time.dat")


### PR DESCRIPTION
Used for analyzing dihedrals between 0°--360° instead of -180° -- 180°.

Useful for dihedrals in anti conformation so that time series and distributions are continuous.