### PR TITLE
Fix GitHub CI

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [7, 8, 9]
+         gcc_v: [7, 9, 10]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -80,7 +80,7 @@ jobs:
     needs: basic_build
     strategy:
       matrix:
-         gcc_v: [7, 8, 9]
+         gcc_v: [7, 9, 10]
     env:
       FC: gfortran
       FFLAGS: -O3 -fopenmp -Wall
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [7, 8, 9]
+         gcc_v: [7, 9, 10]
          mpich_v: ["3.3.2", "3.4.1"]
     env:
       # To speed-up MPICH build
@@ -205,16 +205,24 @@ jobs:
 
     - name: Build and Install MPICH
       if: steps.mpich-cache.outputs.cache-hit != 'true'
-      run: ./dev_scripts/install_mpich.sh ${HOME}/mpich ${MPICH_V}
+      # Without the extra "-fallow-argument-mismatch" FFLAG, configure with GFortran-10 fails with:
+      # "The Fortran compiler gfortran does not accept programs
+      # that call the same routine with arguments of different types"
+      # Unfortunately, previous GCC versions do not have this flag
+      # so we need to set it conditionally.
+      # We also need to set it for ABIN compilation below.
+      run: |
+        if [ $GCC_V -eq 10 ];then export FFLAGS="-fallow-argument-mismatch $FFLAGS";fi && \
+        ./dev_scripts/install_mpich.sh ${HOME}/mpich ${MPICH_V}
 
     - name: build ABIN
-      run:  ./configure --mpi ${HOME}/mpich/${MPICH_V}/install && make
+      run: |
+        if [ $GCC_V -eq 10 ];then export FFLAGS="-fallow-argument-mismatch $FFLAGS";fi && \
+        ./configure --mpi ${HOME}/mpich/${MPICH_V}/install && make
       env:
         FFLAGS: ${{ env.ABIN_FFLAGS }} -g
     - name: test ABIN
       run: make test
-      # We upload to Codecov from the OpenMPI build,
-      # so no need to do that here.
     - name: Codecov upload
       run:  cd src && bash <(curl -s https://codecov.io/bash) $CODECOV_OPTIONS -U "$CURL_OPTS"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/28882168.svg)](https://zenodo.org/badge/latestdoi/28882168)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1228462.svg)](https://zenodo.org/badge/latestdoi/28882168)
 [![CI](https://github.com/PHOTOX/ABIN/workflows/GFortran%20CI/badge.svg?branch=master&event=push)](https://github.com/PHOTOX/ABIN/actions?query=workflow%3A%22GFortran+CI%22)
 [![codecov](https://codecov.io/gh/PHOTOX/ABIN/branch/master/graph/badge.svg)](https://codecov.io/gh/PHOTOX/ABIN)
 

--- a/dev_scripts/install_mpich.sh
+++ b/dev_scripts/install_mpich.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Install OpenMPI implementation of Message Passing Interface (MPI)
-# This script installs both the MPI compilers (mpifort,mpicc)
-# and MPI process manager (mpirun)
+# Install the MPICH implementation of Message Passing Interface (MPI).
+# This script installs both the MPI compilers (mpifort, mpicc)
+# and the MPI process manager (mpirun).
 
 # Exit script immediately upon error
 set -euo pipefail
@@ -10,7 +10,7 @@ set -euo pipefail
 # Path as an optional first parameter
 MPICH_DIR="${1-/home/$USER/mpich}"
 # We take current stable version as default
-# (as of 06 Nov 2020)
+# (as of 06 Nov 2020).
 MPICH_VERSION="${2-"3.3.2"}"
 
 TAR_FILE="mpich-${MPICH_VERSION}.tar.gz"
@@ -54,7 +54,7 @@ make -j $NCPUS 2>&1 | tee make.log
 make install 2>&1 | tee make_install.log
 
 echo "
-Succesfully installed MPICH!
+Succesfully installed MPICH-${MPICH_VERSION}!
 Set the following path in your ABIN make.vars
 
 MPI_PATH = ${INSTALL_DIR}

--- a/tests/REMD/test.sh
+++ b/tests/REMD/test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-rm -f remd.out restart.xyz.??.old output output2 restart.xyz.?? restart.xyz.??.? geom.dat.?? movie.xyz.?? cp2k.out temper.dat.?? energies.dat.?? 
+rm -f remd.out abin.out restart.xyz.??.old restart.xyz.?? restart.xyz.??.? geom.dat.?? movie.xyz.?? cp2k.out temper.dat.?? energies.dat.??
 if [[ "$1" = "clean" ]];then
    exit 0
 fi


### PR DESCRIPTION
Apparently, GCC-8 has been removed from the
Ubuntu-18.04 base image in favour of GCC-10
so we need to adjust.

We still use GCC-7 since this is what is available
on PHOTOX clusters. That's also why we cannot switch
to Ubuntu-20.04 image as it only provides GCC-9/10

I also needed to tweak the FFLAGS for MPI compilation
with GCC-10. The new GFortran does not like when different
types are passed into the same functions (which is typical
for MPI_Send/MPI_Recv).

Lastly, I tried to fix the misbehaving Zenodo badge in README.

NOTE: The Codecov changes here correspond to the previous PR (TC-MPI), since the merge on master failed the tests.