### PR TITLE
Refactor r.abin and r.terabin

### DIFF
--- a/dev_scripts/install_mpich.sh
+++ b/dev_scripts/install_mpich.sh
@@ -21,16 +21,24 @@ INSTALL_DIR="$MPICH_DIR/$MPICH_VERSION/install"
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
 NCPUS=2
 
-if [[ -d $MPICH_DIR/$MPICH_VERSION ]];then
-  echo "Found existing MPICH installation in $MPICH_DIR/$MPICH_VERSION"
+if [[ -d $INSTALL_DIR ]];then
+  echo "Found existing MPICH installation in $INSTALL_DIR"
   echo "Remove this folder if you want to reinstall"
   exit 1
 fi
 
-mkdir -p $MPICH_DIR/$MPICH_VERSION/src
-mkdir -p $MPICH_DIR/$MPICH_VERSION/pkg
+if [[ ! -d $MPICH_DIR/$MPICH_VERSION/pkg ]];then
+  mkdir -p $MPICH_DIR/$MPICH_VERSION/pkg
+fi
 
-curl "$DOWNLOAD_URL" > $MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE}
+if [[ ! -f  $MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE} ]];then
+  curl "$DOWNLOAD_URL" > $MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE}
+fi
+
+if [[ -d $MPICH_DIR/$MPICH_VERSION/src ]];then
+  rm -rf $MPICH_DIR/$MPICH_VERSION/src
+fi
+mkdir -p $MPICH_DIR/$MPICH_VERSION/src
 cd $MPICH_DIR/$MPICH_VERSION/src && tar -xzf ../pkg/${TAR_FILE} && cd mpich-${MPICH_VERSION}
 
 # If you're building MPI for general use, not only for ABIN,

--- a/interfaces/ORCA/r.orca
+++ b/interfaces/ORCA/r.orca
@@ -7,19 +7,18 @@ ibead=$2
 input=input$ibead
 natom=$(cat ../geom.dat.$ibead | wc -l )
 
-rm *engrad
+rm -f *engrad
 
-#TODO, i'm not quite sure, whether we always get the correct energies,
-#but perhaps we do, check the format of $input.engrad
+#TODO: I'm not quite sure, whether we always get the correct energies,
+# but perhaps we do, check the format of $input.engrad
 cat > $input << EOF
-! PAL1  #number of processors
 # in the following line, specify basis sets and method,
 # basis sets for RI approximations are basis/J
-! RI BP86 SVP SVP/J
+! BP86 SVP
 ! ENGRAD AUTOSTART TightSCF
 * xyz 0 1
 EOF
-########END OF USE MODIFICATIONS###################
+### END OF USER INPUT ###
 
 cat ../geom.dat.$ibead >> $input
 echo '*' >>$input
@@ -40,4 +39,3 @@ if ($4=="gradient") {getline;
 	for(i=1;i<=natom;i++) {
 		getline; x=$1;getline;y=$1;getline;print x,y,$1
  }}}' $input.engrad > ../engrad.dat.$ibead
-

--- a/src/tera_mpi_api.F90
+++ b/src/tera_mpi_api.F90
@@ -231,13 +231,13 @@ contains
       use mod_system, only: names
       integer :: itera
 
-      !$OMP PARALLEL DO
+!$OMP PARALLEL DO
       do itera = 1, nteraservers
          call send_natom(natqm, tc_comms(itera))
 
          call send_atom_types_and_scrdir(names, natqm, 0, tc_comms(itera), .false.)
       end do
-      !$OMP END PARALLEL DO
+!$OMP END PARALLEL DO
    end subroutine initialize_tc_servers
 
    subroutine finalize_terachem(abin_error_code)

--- a/tests/test_tc_server_utils.sh
+++ b/tests/test_tc_server_utils.sh
@@ -126,14 +126,14 @@ check_running_processes() {
   MAX_ITER=100
   iter=1
   while true;do
-    running=$(ps -eo pid|grep -E "$regex"|wc -l)
+    running=$(ps -eo pid | egrep "$regex" | wc -l)
     if [[ $running -eq 0 ]];then
       #echo "Both ABIN and TeraChem servers stopped"
       break
     elif [[ $running -lt $num_jobs ]];then
       # Give the others time to finish 
       sleep 1.2
-      running=$(ps -eo pid|grep -E "$regex"|wc -l)
+      running=$(ps -eo pid | egrep "$regex" | wc -l)
       if [[ $running -ne 0 ]];then
         echo "One of the TC servers or ABIN died. Killing the rest."
         cat ${ABINOUT}* ${TCOUT}*

--- a/utils/r.abin
+++ b/utils/r.abin
@@ -1,145 +1,147 @@
 #!/bin/bash
 
 # This is a sample script for launching ABIN simulations in cluster environments.
-# 1. Copy all data from $PWD to the node's scratch. 
+# 1. Copy all files from $PWD to the node's scratch directory.
 #    (not copying folders except for the BASH-interface folder)
 # 2. Launch ABIN.
 # 3. Copy data back (only newer files are copied!).
-# 4. Remove scratch directory. (if delscratch = true)
+# 4. Remove scratch directory.
+
+set -euo pipefail
 
 # Example SGE params for PHOTOX clusters
-#$ -V -cwd
-##$ -q aq -pe shm 3
+#$ -cwd -notify
+#$ -q aq -pe shm 1
 
 # Example SLURM parameters
 #SBATCH --mem=1000
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 
-# SETUP # 
-OUTPUT=output
+### SETUP ###
 JOBNAME=ABIN_${JOB_ID}_$$
-INPUTPARAM=input.in
-INPUTGEOM=mini.dat
-delscratch=true
-INPUTVELOC=
-# SETUP END # 
+ABIN_IN="input.in"
+ABIN_OUT="abin.out"
+GEOM_IN="mini.xyz"
+VELOC_IN=
+#############
 
 SCRDIR=/scratch/$USER/$JOBNAME
 
-# In SLURM, we might already have a dedicated directory
-if [[ ! -z $SLURM_TMPDIR ]];then
-   SCRDIR=$SLURM_TMPDIR
-fi
+function copy_to_scrdir() {
+  # In SLURM, we might already have a dedicated directory
+  if [[ -n ${SLURM_TMPDIR-} ]];then
+    SCRDIR=$SLURM_TMPDIR
+  elif [[ -d $SCRDIR ]];then
+    echo "ERROR: Job directory $SCRDIR already exist!" >&2
+    echo "Perhaps it's a leftover from some old job." >&2
+    exit 1
+  else
+    mkdir $SCRDIR
+  fi
+
+  # First, copy only files, not directories.
+  cp -p $(find . -maxdepth 1 -type f) $SCRDIR/.
+
+  if [[ -d $INTERFACE ]];then
+    cp -r $INTERFACE $SCRDIR/
+  fi
+  if [[ -d $INTERFACE_REF ]];then
+    cp -r $INTERFACE_REF $SCRDIR/
+  fi
+  if [[ -d MM ]];then
+    cp -r MM $SCRDIR/
+  fi
+}
+
+function copy_from_scrdir() {
+  echo "Copying from scratch directory back to $LAUNCH_DIR"
+  rsync -auvz * $LAUNCH_DIR
+  if [[ $? -ne "0" ]];then
+    echo "Error when copying the data from scratch directory back to the server." >&2
+    echo "I will keep the directory $SCRDIR on node:" >&2
+    uname -a >&2
+    exit 1
+  fi
+
+  rm $LAUNCH_DIR/job.log
+  rm -r $SCRDIR
+}
 
 function files_exist {
    for file in $* ;
    do
       if [ ! -f $file ];then
-         echo "ERROR: Cannot find file $file"
+         echo "ERROR: Cannot find file $file" >&2
          error=1
       fi
    done
-   if [[ ! -z $error ]];then
+   if [[ -n ${error-} ]];then
       exit 1
    fi
 }
 
-files_exist $INPUTPARAM
-if [[ ! -z $INPUTVELOC ]];then
-   files_exist $INPUTVELOC
-fi
+function parse_input() {
+  # TODO: This is rather brittle, need better regex
+  pot=$(awk -F"[! ,=\"']+" '{if($1=="pot")print $2}' $ABIN_IN)
+  # Upper case, this is the folder with file interface
+  INTERFACE=${pot^^}
 
-# REMD SETTINGS, automatic from ABIN input (EXPERIMENTAL!)
-N_REPLICAS=1
-grep -E -q -e ^[^!]*iremd[[:space:]]*=[[:space:]]*1\\b $INPUTPARAM
-if [[ $? -eq 0 ]];then
-   N_REPLICAS=$(grep -E -o -e ^[^!]*nreplica[[:space:]]*=[[:space:]]*[0-9]+ $INPUTPARAM | grep -E -o -e [0-9]+)
-   REMD=true
-   echo "REMD detected. Number of replicas = $N_REPLICAS"
-fi
+  # when using reference potential for multiple timestepping
+  pot_ref=$(awk -F"[! ,=\"']+" '{if($1=="pot_ref")print $2}' $ABIN_IN)
+  INTERFACE_REF=${pot_ref^^}
+
+  # automatic REMD settings from ABIN input
+  N_REPLICAS=1
+  test=$(egrep -o -e ^[^!]*iremd[[:space:]]*=[[:space:]]*1\\b $ABIN_IN || true)
+  if [[ -n $test ]];then
+    echo "REMD detected. Assuming one TC server per replica!"
+    N_REPLICAS=$(egrep -o -e ^[^!]*nreplica[[:space:]]*=[[:space:]]*[0-9]+\\b $ABIN_IN | egrep -o -e [0-9]+|| true)
+    if [[ -z $N_REPLICAS ]];then
+      echo "ERROR: Could not determine the number of replicas from $ABIN_IN" >&2
+      exit 1
+    fi
+    REMD=true
+    echo "REMD detected. Number of replicas = $N_REPLICAS"
+  fi
+}
+
+files_exist $ABIN_IN
+parse_input
 
 # $ABINEXE exported via SetEnvironment.sh
-if [[ $REMD == "true" ]];then
-   # TODO: We currently allow only <100 replicas
-   files_exist $INPUTGEOM.[0-9][0-9]
-   source SetEnvironment.sh ABIN mpi
-   ABINEXE="$MPIRUN -n $N_REPLICAS $ABINEXE"
-else
-   files_exist $INPUTGEOM
-   source SetEnvironment.sh ABIN
+set +u
+source SetEnvironment.sh ABIN
+set -u
+if [[ ${REMD-} == "true" ]];then
+  ABINEXE="$MPIRUN -n $N_REPLICAS $ABINEXE"
 fi
 
-
-# TODO: This is rather brittle, need better regex
-pot=$(awk -F"[! ,=\"']+" '{if($1=="pot")print $2}' $INPUTPARAM)
-# Upper case, this is the folder with file interface
-INTERFACE=${pot^^}
-
-# when using reference potential for multiple timestepping
-pot_ref=$(awk -F"[! ,=\"']+" '{if($1=="pot_ref")print $2}' $INPUTPARAM)
-INTERFACE_REF=${pot_ref^^}
-
-
-# TODO: Check that the MD run in existing job.log is not running anymore
 uname -n > job.log
 echo "$SCRDIR" >> job.log
 
 LAUNCH_DIR=$PWD
 
-if [[ -d $SCRDIR ]];then
-   if [[ -z $SLURM_TMPDIR ]];then
-      echo "Job direcory $SCRDIR already exist!"
-      echo "Perhaps it's a leftover from some old job, you could probably delete it."
-      exit 1
-   fi
-else
-   mkdir $SCRDIR
-fi
-
-# The local SetEnvironment script is sourced in file-based ab initio interfaces so that they are system-agnostic.
-# We need to use local copy because when global copy was updated ABIN simulations were crashing.
-# We always copy new version to local folder, since outdated versions can lead to bugs.
-# The downside is that when you restart simulation you are not quite guaranteed 
-# that you will use the same version of the ab initio program (e.g. when new version is installed on your cluster)
+# The local SetEnvironment script is sourced in file-based ab initio interfaces
+# so that they are system-agnostic.
+# We need to use local copy because when global copy
+# happened to change, running ABIN simulations were crashing.
+# We always copy a new version to local folder,
+# since outdated versions can lead to bugs.
+# The downside is that when you restart a simulation,
+# you are not quite guaranteed that you will use the same version
+# of the ab initio program (e.g. when new version is installed on your cluster).
 OURSETENV=$(which SetEnvironment.sh)
 cp $OURSETENV .
 
-# TODO: Use rsync here
-cp -p * $SCRDIR/.
-if [[ -d $INTERFACE ]];then
-   cp -r $INTERFACE $SCRDIR/
-fi
-if [[ -d $INTERFACE_REF ]];then
-   cp -r $INTERFACE_REF $SCRDIR/
-fi
-if [[ -d MM ]];then
-   cp -r MM $SCRDIR/
-fi
+copy_to_scrdir
+
+trap copy_from_scrdir EXIT SIGUSR2
 
 cd $SCRDIR
 
-# TODO Trap signals from SGE and SLURM
-
-if [[ -z $INPUTVELOC ]];then
-   $ABINEXE -i $INPUTPARAM -x $INPUTGEOM >> $OUTPUT
+if [[ -z $VELOC_IN ]];then
+   $ABINEXE -i $ABIN_IN -x $GEOM_IN >> $ABIN_OUT
 else
-   $ABINEXE -v $INPUTVELOC -i $INPUTPARAM -x $INPUTGEOM >> $OUTPUT
+   $ABINEXE -v $VELOC_IN -i $ABIN_IN -x $GEOM_IN >> $ABIN_OUT
 fi
-
-# TODO: Use rsync here
-cp -upr * $LAUNCH_DIR/
-if [[ $? -ne "0" ]];then
-   echo "Error when copying the data from scratch back to the server."
-   echo "I will keep the directory $SCRDIR on node:"
-   uname -a
-   exit 1
-fi
-
-cd ..
-
-if [[ $delscratch -eq "true" ]];then
-   rm -r $SCRDIR 
-   rm $LAUNCH_DIR/job.log
-fi
-

--- a/utils/r.terabin
+++ b/utils/r.terabin
@@ -1,9 +1,11 @@
 #!/bin/bash
-# This is a sample script for launching ABIN simulations in cluster environments
-# using MPI TeraChem interface.
+# This is a sample script for launching an ABIN simulation
+# in cluster environments using MPI TeraChem interface.
+
+set -euo pipefail
 
 # Sample SGE Params on PHOTOX clusters
-#$ -V -cwd
+#$ -V -cwd -notify
 #$ -l num_gpu=1
 #$ -pe shm 1 -q nq-gpu
 
@@ -14,157 +16,219 @@
 #SBATCH --cpus-per-task=1
 #SBATCH --gres=gpu:1
 
-JOBNAME=TERABIN_${JOB_ID}_$$
 # ABIN SETUP 
 ABIN_OUT=abin.out
 ABIN_IN=input.in
-INPUTGEOM=water.xyz
-INPUTVELOC=
+GEOM_IN=mini.xyz
+VELOC_IN=
 
-# TeraChem SETUP
-TC_INPUT=tera.inp
+TC_IN=tc.inp
 MPITYPE=0   # 0 - ground state AIMD
             # 2 - Surface Hopping
-delscratch=true
-N_TERA_SERVERS=1     # Use more TC servers for PIMD or REMD (Experimental)
 ################
 
-function files_exist {
+JOBNAME=TERABIN_${JOB_ID}_$$
+
+USE_HYDRA_NAMESERVER="false"
+
+SCRDIR=/scratch/$USER/$JOBNAME
+LAUNCH_DIR=$PWD
+
+function copy_to_scrdir() {
+  if [[ -d $SCRDIR ]];then
+    echo "ERROR: Job directory $SCRDIR already exist!" >&2
+    echo "Perhaps it's a leftover from some old job." >&2
+    exit 1
+  fi
+
+  mkdir $SCRDIR
+
+  # Copying only files, not directories.
+  cp -p $(find . -maxdepth 1 -type f) $SCRDIR/.
+
+  if [[ -d $INTERFACE_REF ]];then
+    cp -r $INTERFACE_REF $SCRDIR/
+  fi
+}
+
+function copy_from_scrdir() {
+  echo "Copying scratch back to $LAUNCH_DIR"
+  rsync -auvz * $LAUNCH_DIR
+  if [[ $? -ne "0" ]];then
+    echo "Error when copying the data from scratch back to the server." >&2
+    echo "I will keep the directory $SCRDIR on node:" >&2
+    uname -a >&2
+    exit 1
+  fi
+
+  rm $LAUNCH_DIR/job.log
+  rm -r $SCRDIR
+}
+
+function files_exist() {
    for file in $* ;
    do
       if [[ ! -f $file ]];then
-         echo "ERROR: Cannot find file $file"
+         echo "ERROR: Cannot find file $file" >&2
          error=1
       fi
    done
-   if [[ ! -z $error ]];then
+   if [[ -n ${error-} ]];then
       exit 1
    fi
 }
 
-files_exist $TC_INPUT $ABIN_IN
+function launch_hydra_nameserver() {
+  hydra=$(ps -C hydra_nameserver -o pid= || true)
+  if [[ -z $hydra ]]; then
+    MPIPATH=$(dirname $MPIRUN)
+    echo "Launching hydra nameserver for MPI_Lookup"
+    if [[ -f $MPIPATH/hydra_nameserver ]]; then
+      $MPIPATH/hydra_nameserver &
+    else
+      echo "ERROR: Could not find hydra_nameserver executable" >&2
+      exit 1
+    fi
+  fi
+}
 
-# Check pot=_tera_ in ABIN input
-grep -E -q -e ^[^!]*pot[[:space:]]*=[[:space:]]*[\'"]_tera_["\'] $ABIN_IN
-if [[ $? -eq 1 ]];then
-   echo "ERROR: It appears that you did not specify pot=\'_tera_\' in $ABIN_IN."
-   exit 1 
-fi
+function grep_tc_port {
+  tcout=$1
+  portfile=$2
+  maxiter=10
+  i=0
+  # Grep port name from TC output, pass to ABIN via a file.
+  tcport=$(awk '/port_name:/ {print $(NF);exit}' $tcout)
+  while [[ -z ${tcport} ]]; do
+    if [[ $i -gt $maxiter ]];then
+      echo "ERROR: Could not grep port name from $tcout" >&2
+      exit 1
+    fi
+    sleep 1
+    tcport=$(awk '/port_name:/ {print $(NF);exit}' $tcout)
+    let ++i
+  done
+  echo $tcport > $portfile
+}
 
-# automatic REMD settings from ABIN input
-N_REPLICAS=1
-grep -E -q -e ^[^!]*iremd[[:space:]]*=[[:space:]]*1\\b $ABIN_IN
-if [[ $? -eq 0 ]];then
+function validate_inputs() {
+  files_exist $TC_IN $ABIN_IN
+
+  # Check pot=_tera_ in ABIN input
+  test=$(egrep -o -e ^[^!]*pot[[:space:]]*=[[:space:]]*[\'\"]_tera_[\"\'] $ABIN_IN || true)
+  if [[ -z $test ]];then
+    echo "ERROR: You did not specify pot='_tera_' in $ABIN_IN." >&2
+    exit 1 
+  fi
+}
+
+function parse_inputs() {
+
+  N_TERA_SERVERS=$(egrep -o -e ^[^!]*nteraservers[[:space:]]*=[[:space:]]*[0-9]+\\b $ABIN_IN | egrep -o -e [0-9]+|| true)
+  # Set default if not specified in the ABIN input.
+  : ${N_TERA_SERVERS:=1}
+
+  # automatic REMD settings from ABIN input
+  N_REPLICAS=1
+  test=$(egrep -o -e ^[^!]*iremd[[:space:]]*=[[:space:]]*1\\b $ABIN_IN || true)
+  if [[ -n $test ]];then
     echo "REMD detected. Assuming one TC server per replica!"
-    # TODO: Simplify this with AWK
-    N_REPLICAS=$(grep -E -o -e ^[^!]*nreplica[[:space:]]*=[[:space:]]*[0-9]+ $ABIN_IN | grep -E -o -e [0-9]+)
+    N_REPLICAS=$(egrep -o -e ^[^!]*nreplica[[:space:]]*=[[:space:]]*[0-9]+\\b $ABIN_IN | egrep -o -e [0-9]+|| true)
     if [[ -z $N_REPLICAS ]];then
-      echo "ERROR: Could not determine the number of replicas from $ABIN_IN"
+      echo "ERROR: Could not determine the number of replicas from $ABIN_IN" >&2
       exit 1
     fi
     N_TERA_SERVERS=$N_REPLICAS
-else
-    files_exist $INPUTGEOM
-    if [[ ! -z $INPUTVELOC ]];then
-        files_exist $INPUTVELOC
-    fi
+  fi
+
+  # When using a reference potential in multiple time-step MD,
+  # we need to copy an extra directory.
+  pot_ref=$(awk -F"[! ,=\"']+" '{if($1=="pot_ref")print $2}' $ABIN_IN)
+  INTERFACE_REF=${pot_ref^^}
+
+  if [[ -n ${NSLOTS-} && $NSLOTS -ne $N_TERA_SERVERS ]];then
+    echo "ERROR: Number of requested GPUs ($NSLOTS)" >&2
+    echo "is not equal to the number of TC servers ($N_TERA_SERVERS)" >&2
+    exit 1
+  fi
+}
+
+# All auxiliary functions defined, let's GO!
+validate_inputs
+parse_inputs
+
+# SET THE ENVIRONMENT
+set +ux
+source SetEnvironment.sh TERACHEM
+source SetEnvironment.sh ABIN
+set -ux
+
+if [[ $N_TERA_SERVERS -gt 1 ]];then
+  # hydra_nameserver <= v3.4.1 does not work with multiple servers.
+  USE_HYDRA_NAMESERVER=false
 fi
 
-export LD_LIBRARY_PATH=
-source SetEnvironment.sh TERACHEM
-source SetEnvironment.sh ABIN mpi
 export OMP_NUM_THREADS=$N_TERA_SERVERS
-hostname=$HOSTNAME
-MPIRUN_TERA="$MPIRUN -n 1 -nameserver $hostname"
-MPIRUN_ABIN="$MPIRUN -n $N_REPLICAS -nameserver $hostname"
+MPIRUN_ABIN="$MPIRUN -n $N_REPLICAS"
+MPIRUN_TERA="$MPIRUN -n 1"
+if [[ $USE_HYDRA_NAMESERVER = "true" ]];then
+  MPIRUN_ABIN="${MPIRUN_ABIN} -nameserver $HOSTNAME"
+  MPIRUN_TERA="${MPIRUN_TERA} -nameserver $HOSTNAME"
+fi
 
-# when using reference potential in multiple time-step MD
-# TODO: This is very brittle
-pot_ref=$(awk -F"[! ,=\"']+" '{if($1=="pot_ref")print $2}' $ABIN_IN)
-INTERFACE_REF=${pot_ref^^}
-
-SCRDIR=/scratch/$USER/$JOBNAME
-
+# HERE WE GO!
 uname -n > job.log
 echo "$SCRDIR" >> job.log
 
-LAUNCH_DIR=$PWD
-
-if [[ -d $SCRDIR ]];then
-   echo "ERROR: Job directory $SCRDIR already exist!"
-   echo "Perhaps it's a leftover from some old job, you could probably delete it."
-   exit 1
-else
-   mkdir $SCRDIR
-fi
-
-cp -p * $SCRDIR/.
-
-if [[ -d $INTERFACE_REF ]];then
-   cp -r $INTERFACE_REF $SCRDIR/
-fi
-
+copy_to_scrdir
 cd $SCRDIR
 
 TC_PORT=$JOBNAME.$$
-# Make sure hydra_nameserver is running
-hydra=$(ps -e | grep hydra_nameser)
-if [[ -z $hydra ]];then
-   MPIPATH=$(dirname $MPIRUN)
-   echo "Launching hydra nameserver for MPI_Lookup"
-   if [[ -f $MPIPATH/hydra_nameserver ]];then
-      $MPIPATH/hydra_nameserver &
-   else
-      echo "ERROR: Could not find hydra_nameserver executable"
-      exit 1
-   fi
+if [[ $USE_HYDRA_NAMESERVER = "true" ]]; then
+  launch_hydra_nameserver
 fi
 
-let NUM_JOBS=N_TERA_SERVERS+1
-declare -A job_pids
+trap copy_from_scrdir EXIT SIGUSR2
 
+declare -A job_pids
 # LAUNCH TERACHEM
 for ((itera=1;itera<=N_TERA_SERVERS;itera++)) {
-   let gpuid=itera-1
-   $MPIRUN_TERA $TERAEXE -g$gpuid --inputfile=$TC_INPUT --UseMPI=$MPITYPE --MPIPort=$TC_PORT.$itera > $TC_INPUT.out.$itera 2>&1 &
-   job_pids[$itera]=$!
+   gpuid=$((itera-1))
+   $MPIRUN_TERA $TERAEXE -g$gpuid --inputfile=$TC_IN --UseMPI=$MPITYPE --MPIPort=$TC_PORT.$itera > $TC_IN.out.$itera 2>&1 &
+   job_pids[tc_$itera]=$!
 }
 
+if [[ $USE_HYDRA_NAMESERVER != "true" ]];then
+  TC_PORT_FILE="port.txt"
+  # Grep port names from TC output, pass to ABIN via a file.
+  for ((itera=1;itera<=N_TERA_SERVERS;itera++)); do
+    grep_tc_port $TC_IN.out.$itera  $TC_PORT_FILE.$itera
+  done
+fi
+
 # LAUNCH ABIN
-ABIN_CMD="$ABINEXE -i $ABIN_IN -x $INPUTGEOM -M $TC_PORT"
-if [[ -z $INPUTVELOC ]];then
-   ABIN_CMD=$ABIN_CMD" -v $INPUTVELOC"
+ABIN_CMD="$ABINEXE -i $ABIN_IN -x $GEOM_IN"
+if [[ $USE_HYDRA_NAMESERVER = "true" ]];then
+  ABIN_CMD="$ABIN_CMD -M $TC_PORT"
+fi
+if [[ -z $VELOC_IN ]];then
+   ABIN_CMD=$ABIN_CMD" -v $VELOC_IN"
 fi
 $MPIRUN_ABIN $ABIN_CMD > $ABIN_OUT 2>&1 &
-job_pids[$NUM_JOBS]=$!
+job_pids[abin]=$!
 
-# CHECK WHETHER ABIN AND TC ARE RUNNING
+# PERIODICALLY CHECK WHETHER ABIN AND TC ARE RUNNING
 function join_by { local IFS="$1"; shift; echo "$*"; }
 regex=`join_by \| ${job_pids[@]}`
 while true;do
-   njobs=$(ps -eo pid|grep -E "$regex"|wc -l)
+   njobs=$(ps -eo pid | egrep "$regex" | wc -l)
    if [[ $njobs -eq 0 ]];then
       echo "Both ABIN and TeraChem stopped"
       break
-   elif [[ $njobs -lt $NUM_JOBS ]];then
-      echo "One of the TC servers or ABIN died. Killing the rest."
+   elif [[ $njobs -lt ${#job_pids[@]} ]];then
+      echo "One of the TC servers or ABIN died. Killing the rest." >&2
       kill -9 ${job_pids[@]} 
       break
    fi
-   sleep 10
+   sleep 3
 done
-
-cp -upr * $LAUNCH_DIR/.
-if [[ $? -ne "0" ]];then
-   echo "Error when copying the data from scratch back to the server."
-   echo "I will keep the directory $SCRDIR on node:"
-   uname -a
-   exit 1
-fi
-
-cd ..
-
-if [[ $delscratch -eq "true" ]];then
-   rm -r $SCRDIR
-   rm $LAUNCH_DIR/job.log
-fi


### PR DESCRIPTION
- move code into BASH functions for better readability

- automatically exit on error for better debugging/robustnesss

- use rsync instead of cp for safer and faster sync from scrdir

- `r.terabin`: By default do not use `hydra_nameserver`