### PR TITLE
Refactor error handling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,12 @@ the GNU General Public License, either version 3 of the License,
 or any later version, except for parts noted below.
 A copy of this license is given later in this file. 
 
-The random number generator in random.f90 was kindly provided by prof. M. Lewerenze
-and is distributed under the GNU GPL v3 license. See random.f90
+The random number generator in src/random.F90 was kindly provided by prof. M. Lewerenze
+and is distributed under the GNU GPL v3 license. For details see random.F90.
+
+Files unit_test/throw_with_pfunit.F90 and src/error.F90 were adapted from
+the [pFUnit_demos repository](https://github.com/Goddard-Fortran-Ecosystem/pFUnit_demos)
+and are distributed under the Apache License version 2.0, see http://www.apache.org/licenses/.
 
 ==============================================================================
 Here is the text of the GPL license:

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ test: unittest e2etest
 
 # Clean all test folders.
 testclean:
+ifneq ($(strip $(PFUNIT_PATH)),)
+	$(MAKE) -C unit_tests clean
+endif
 	/bin/bash tests/test.sh ${BIN} $(TEST) ${MPI} ${FFTW} $(PLUMED) ${CP2K} clean
 
 # This will automatically generate new reference data for E2E tests

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-F_OBJS := modules.o fortran_interfaces.o utils.o io.o random.o arrays.o qmmm.o fftw_interface.o \
+F_OBJS := modules.o fortran_interfaces.o error.o utils.o io.o random.o arrays.o qmmm.o fftw_interface.o \
           shake.o nosehoover.o gle.o transform.o potentials.o estimators.o ekin.o vinit.o plumed.o \
           remd.o force_bound.o water.o force_cp2k.o sh_integ.o surfacehop.o landau_zener.o\
           force_mm.o tera_mpi_api.o force_tera.o force_terash.o force_abin.o en_restraint.o analyze_ext_template.o geom_analysis.o analysis.o \

--- a/src/abin.F90
+++ b/src/abin.F90
@@ -285,6 +285,11 @@ program abin
       ! MINIMIZATION endif
    end if
 
+   if (my_rank == 0) then
+      write (*, *) ''
+      write (*, '(A)') 'Job finished successfully!'
+   end if
+
    call finish(0)
 
    ! FINAL TIMING

--- a/src/error.F90
+++ b/src/error.F90
@@ -59,7 +59,7 @@ contains
       write (ERROR_UNIT, '(A)') full_message
 
       open (newunit=iunit, file=ERROR_FILE, action='write')
-      write (iunit, '(a)') full_message
+      write (iunit, '(a)') 'ERROR: '//message
       close (unit=iunit)
 
       call flush (OUTPUT_UNIT)

--- a/src/error.F90
+++ b/src/error.F90
@@ -16,7 +16,7 @@
 !   default behavior with a call to set_error_method(). This logic
 !   can comfortably live in your test code, and thus does not
 !   introduce any undesirable dependencies (just a bit of
-!   obscurity). 
+!   obscurity).
 module mod_error
    implicit none
    private
@@ -47,7 +47,7 @@ contains
    end subroutine set_error_method
 
    ! filename and line_number parameters should be passed using the preprocessor
-   ! defined constants __FILENAME__ and __LINE__
+   ! defined constants __FILE__ and __LINE__
    subroutine fatal_error(filename, line_number, message)
       character(len=*), intent(in) :: filename
       integer, intent(in) :: line_number

--- a/src/error.F90
+++ b/src/error.F90
@@ -3,54 +3,71 @@ module mod_error
    private
 
    public :: fatal_error
-   ! This method is used by pFUnit to set it's own error handler. 
+   ! This method is used by pFUnit to set it's own error handler.
    ! Therefore, this method and its name cannot be changed!
-   public :: set_throw_method
+   public :: set_error_method
 
    abstract interface
       subroutine error(filename, line_number, message)
          character(len=*), intent(in) :: filename
          integer, intent(in) :: line_number
-         character(len=*), optional, intent(in) :: message
+         character(len=*), intent(in) :: message
       end subroutine error
    end interface
 
-   procedure (error), pointer :: throw_method => Fail
+   procedure(error), pointer :: error_method => Fail
 
 contains
 
-   subroutine set_throw_method(method)
-      procedure (error) :: method
-      throw_method => method
-   end subroutine set_throw_method
+   subroutine set_error_method(method)
+      procedure(error) :: method
+      error_method => method
+   end subroutine set_error_method
 
    ! This should superseed abinerror()
    subroutine fatal_error(filename, line_number, message)
       character(len=*), intent(in) :: filename
       integer, intent(in) :: line_number
-      character(len=*), optional, intent(in) :: message
+      character(len=*), intent(in) :: message
 
-      call throw_method(filename, line_number, message=message)
+      call error_method(filename, line_number, message=message)
    end subroutine fatal_error
-
 
    ! Part of abinerror should go here.
    subroutine Fail(filename, line, message)
-      use, intrinsic :: iso_fortran_env, only: ERROR_UNIT
+      use, intrinsic :: iso_fortran_env, only: ERROR_UNIT, OUTPUT_UNIT
       character(*), intent(in) :: filename
       integer, intent(in) :: line
-      character(*), optional, intent(in) :: message
+      character(*), intent(in) :: message
       ! In case of any error, ABIN will return this
       integer, parameter :: ERROR_CODE = 1
-      character(:), allocatable :: base_name
-      
+      ! We write out the error message to file 'ERROR'
+      ! Presence of this file straightforwardly indicates a problem.
+      character(len=*), parameter :: ERROR_FILE = 'ERROR'
+      character(len=:), allocatable :: base_name, full_message
+      integer :: iunit, strlen
+
       base_name = get_base_name(filename)
 
-      write (ERROR_UNIT,'(a, a, a1, i0, a)') &
-           & 'ERROR at ', base_name, ':', line, &
-           & ' '//adjustl(trim(message))//' '
+      strlen = len_trim(message) + len(base_name) + 20
+      allocate (character(len=strlen) :: full_message)
 
-      ! TODO: Call finalize here.
+      write (full_message, '(a9, a, a1, i0, a)') &
+           & 'ERROR at ', base_name, ':', line, &
+           & ' '//adjustl(trim(message))
+
+      write (ERROR_UNIT, '(A)') full_message
+
+      open (newunit=iunit, file=ERROR_FILE, action='write')
+      write (iunit, '(a)') full_message
+      close (unit=iunit)
+
+      call flush (OUTPUT_UNIT)
+      call flush (ERROR_UNIT)
+
+      ! Depending on the state of the program, this call might itself fail
+      call finish(ERROR_CODE)
+
       stop ERROR_CODE
    end subroutine Fail
 
@@ -62,7 +79,7 @@ contains
 
       idx = scan(filename, '/', back=.true.)
 
-      base_name = filename(idx+1:)
+      base_name = filename(idx + 1:)
 
    end function get_base_name
 

--- a/src/error.F90
+++ b/src/error.F90
@@ -1,0 +1,69 @@
+module mod_error
+   implicit none
+   private
+
+   public :: fatal_error
+   ! This method is used by pFUnit to set it's own error handler. 
+   ! Therefore, this method and its name cannot be changed!
+   public :: set_throw_method
+
+   abstract interface
+      subroutine error(filename, line_number, message)
+         character(len=*), intent(in) :: filename
+         integer, intent(in) :: line_number
+         character(len=*), optional, intent(in) :: message
+      end subroutine error
+   end interface
+
+   procedure (error), pointer :: throw_method => Fail
+
+contains
+
+   subroutine set_throw_method(method)
+      procedure (error) :: method
+      throw_method => method
+   end subroutine set_throw_method
+
+   ! This should superseed abinerror()
+   subroutine fatal_error(filename, line_number, message)
+      character(len=*), intent(in) :: filename
+      integer, intent(in) :: line_number
+      character(len=*), optional, intent(in) :: message
+
+      call throw_method(filename, line_number, message=message)
+   end subroutine fatal_error
+
+
+   ! Part of abinerror should go here.
+   subroutine Fail(filename, line, message)
+      use, intrinsic :: iso_fortran_env, only: ERROR_UNIT
+      character(*), intent(in) :: filename
+      integer, intent(in) :: line
+      character(*), optional, intent(in) :: message
+      ! In case of any error, ABIN will return this
+      integer, parameter :: ERROR_CODE = 1
+      character(:), allocatable :: base_name
+      
+      base_name = get_base_name(filename)
+
+      write (ERROR_UNIT,'(a, a, a1, i0, a)') &
+           & 'ERROR at ', base_name, ':', line, &
+           & ' '//adjustl(trim(message))//' '
+
+      ! TODO: Call finalize here.
+      stop ERROR_CODE
+   end subroutine Fail
+
+   function get_base_name(filename) result(base_name)
+      character(:), allocatable :: base_name
+      character(*), intent(in) :: filename
+
+      integer :: idx
+
+      idx = scan(filename, '/', back=.true.)
+
+      base_name = filename(idx+1:)
+
+   end function get_base_name
+
+end module mod_error

--- a/src/fftw_interface.F90
+++ b/src/fftw_interface.F90
@@ -66,7 +66,7 @@ contains
    ! Dummy functions when ABIN is not compiled with FFTW
    subroutine fftw_normalmodes_init(nwalk)
       use iso_fortran_env, only: ERROR_UNIT
-      integer :: nwalk
+      integer, intent(inout) :: nwalk
       nwalk = 0
       write (ERROR_UNIT, *) 'ERROR: Normal mode transformation cannot be performed.'
       call not_compiled_with('FFTW library')

--- a/src/fftw_interface.F90
+++ b/src/fftw_interface.F90
@@ -65,10 +65,11 @@ contains
 
    ! Dummy functions when ABIN is not compiled with FFTW
    subroutine fftw_normalmodes_init(nwalk)
+      use iso_fortran_env, only: ERROR_UNIT
       integer :: nwalk
       nwalk = 0
-      write (*, *) 'ERROR: Normal mode transformations cannot be performed.'
-      call not_compiled_with('FFTW library', 'fftw_normalmodes_init')
+      write (ERROR_UNIT, *) 'ERROR: Normal mode transformation cannot be performed.'
+      call not_compiled_with('FFTW library')
    end subroutine fftw_normalmodes_init
 
    subroutine dft_normalmode2cart(nm, cart)
@@ -76,7 +77,7 @@ contains
       real(C_DOUBLE), dimension(:) :: cart
       cart = 0.0D0
       nm = (0.0D0, 0.0D0)
-      call not_compiled_with('FFTW library', 'dft_normalmode2cart')
+      call not_compiled_with('FFTW library')
    end subroutine dft_normalmode2cart
 
    subroutine dft_cart2normalmode(cart, nm)
@@ -84,7 +85,7 @@ contains
       real(C_DOUBLE), dimension(:) :: cart
       cart = 0.0D0
       nm = (0.0D0, 0.0D0)
-      call not_compiled_with('FFTW library', 'dft_cart2normalmode')
+      call not_compiled_with('FFTW library')
    end subroutine dft_cart2normalmode
 
    ! This must be a no-op and must not call abinerror()

--- a/src/force_cp2k.F90
+++ b/src/force_cp2k.F90
@@ -292,7 +292,7 @@ contains
    ! Dummy functions for compilation without CP2K
    subroutine init_cp2k()
       use mod_utils, only: abinerror
-      call not_compiled_with('internal CP2K interface', 'init_cp2k')
+      call not_compiled_with('internal CP2K interface')
    end subroutine init_cp2k
 
    subroutine finalize_cp2k()
@@ -309,7 +309,7 @@ contains
       eclas = 0.0D0
       walkmax = 0
 
-      call not_compiled_with('internal CP2K interface', 'force_cp2k')
+      call not_compiled_with('internal CP2K interface')
    end subroutine force_cp2k
 
 #endif

--- a/src/force_cp2k.F90
+++ b/src/force_cp2k.F90
@@ -292,7 +292,6 @@ contains
    ! Dummy functions for compilation without CP2K
    subroutine init_cp2k()
       use mod_utils, only: abinerror
-      write (*, *) 'ERROR: ABIN was not compiled with CP2K interface.'
       call not_compiled_with('internal CP2K interface', 'init_cp2k')
    end subroutine init_cp2k
 

--- a/src/force_terash.F90
+++ b/src/force_terash.F90
@@ -512,7 +512,7 @@ contains
       real(DP), intent(inout) :: x(:, :), y(:, :), z(:, :)
       ! Assignments just to squash compiler warnings
       x = 0.0D0; y = 0.0D0; z = 0.0D0
-      call not_compiled_with('MPI', 'init_terash')
+      call not_compiled_with('MPI')
    end subroutine init_terash
 
    subroutine force_terash(x, y, z, fx, fy, fz, eclas)
@@ -523,7 +523,7 @@ contains
       real(DP), intent(inout) :: eclas
       ! Assignments just to squash compiler warnings
       fx = x; fy = y; fz = z; eclas = 0.0D0
-      call not_compiled_with('MPI', 'force_terash')
+      call not_compiled_with('MPI')
    end subroutine force_terash
 #endif
 end module mod_terampi_sh

--- a/src/gle.F90
+++ b/src/gle.F90
@@ -299,7 +299,7 @@ contains
    subroutine initialize_momenta(C, iw)
       !use mod_arrays,  only: px, py, pz, vx, vy, vz, amt
       use mod_general, only: natom
-      use mod_utils, only: abinerror, print_xyz_arrays
+      use mod_utils, only: abinerror
       real(DP), intent(in) :: C(:, :)
       integer, intent(in) :: iw
       real(DP), allocatable :: gr(:)
@@ -327,9 +327,6 @@ contains
       !vx = px / amt
       !vy = py / amt
       !vz = pz / amt
-
-      !call print_xyz_arrays(px, py, pz)
-      !call print_xyz_arrays(vx, vy, vz)
 
       do j = 1, natom * 3
          do i = 1, ns

--- a/src/init.F90
+++ b/src/init.F90
@@ -1199,13 +1199,6 @@ subroutine finish(error_code)
    end if
 #endif
 
-   if (my_rank == 0) then
-      write (*, *) ''
-      if (error_code == 0) then
-         write (*, '(A)') 'Job finished!'
-      end if
-   end if
-
    call deallocate_arrays()
 
    ! TODO: Move this to a subroutine in mod_files

--- a/src/modules.F90
+++ b/src/modules.F90
@@ -114,6 +114,7 @@ module mod_general
 end module
 
 ! Some information about simulated system, especially for distributions and shake
+! TODO: Move this to a separate file, and think hard what should be inside this module.
 module mod_system
    use mod_const, only: DP
    ! cannot use this
@@ -442,7 +443,9 @@ contains
 
 end module mod_system
 
-! module for permanent file handling
+! Module for permanent file handling
+! Note that we're not trying to explicitly handle I/O errors here.
+! If open() or write fails, we crash ungracefully.
 ! TODO: Move this to a separate file.
 module mod_files
    implicit none
@@ -649,7 +652,7 @@ contains
 end module mod_files
 
 module mod_chars
-   character(len=*), parameter :: chknow = 'If you know what you are doing, &
+   character(len=*), parameter :: CHKNOW = 'If you know what you are doing, &
     &set iknow=1 (namelist general) to proceed.'
 
 end module mod_chars

--- a/src/plumed.F90
+++ b/src/plumed.F90
@@ -205,7 +205,7 @@ contains
    ! We use this approach to avoid needing to have '#ifdef USE_PLUMED'
    ! elsewhere in the codebase
    subroutine plumed_init()
-      call not_compiled_with('PLUMED', 'plumed_init')
+      call not_compiled_with('PLUMED')
    end subroutine plumed_init
 
    subroutine finalize_plumed()
@@ -224,7 +224,7 @@ contains
       ! Just to get rid of compiler warnings :-(
       fx = x; fy = y; fz = z; eclas = 0.0D0
 
-      call not_compiled_with('PLUMED', 'force_plumed')
+      call not_compiled_with('PLUMED')
    end subroutine force_plumed
 #endif
 

--- a/src/plumed.F90
+++ b/src/plumed.F90
@@ -38,7 +38,8 @@ contains
    subroutine plumed_init(silent_output)
       use mod_general, only: natom, irest, dt0, nrest
       use mod_const, only: ANG, AUTOFS, AMU, AVOGADRO, AUTOJ
-      use mod_utils, only: abinerror, c_string
+      use mod_utils, only: c_string
+      use mod_error, only: fatal_error
       !use mod_nhc, only: temp
       implicit none
       ! Do not print any output (used in unit tests, unittest/test_plumed.pf)
@@ -66,24 +67,23 @@ contains
          silent = silent_output
       end if
 
-      if (.not. silent) then
-         write (*, *) 'PLUMED is ON'
-         write (*, *) 'PLUMED input file is '//trim(plumedfile)
-      end if
-
       ! Initialize the main plumed object.
       ! This must be the very first call.
       call plumed_f_gcreate()
 
       call plumed_f_gcmd(c_string("getApiVersion"), api_version)
+
       if (.not. silent) then
-         write (*, *) "PLUMED API VERSION: ", api_version
+         write (*, '(a)') 'PLUMED is ON'
+         write (*, '(a)') 'PLUMED input file is '//trim(plumedfile)
+         write (*, '(a, i0)') 'PLUMED API version: ', api_version
       end if
 
       if (api_version < MIN_API_VERSION) then
-         write (*, *) 'ERROR: PLUMED version not supported'
-         write (*, *) 'Please, install a newer PLUMED version and recompile ABIN'
-         call abinerror('plumed_init')
+         call fatal_error(__FILE__, __LINE__, &
+                     'PLUMED version not supported. '//&
+                    &'Please, install a newer PLUMED version and recompile ABIN')
+         return
       end if
 
       ! Set units for conversion between PLUMED and ABIN.

--- a/src/remd.F90
+++ b/src/remd.F90
@@ -322,7 +322,7 @@ contains
       use mod_utils, only: not_compiled_with
       real(DP), intent(inout) :: temp, temp0
       temp = 0.0D0; temp0 = 0.0D0
-      call not_compiled_with('MPI', 'remd_init')
+      call not_compiled_with('MPI')
    end subroutine remd_init
 
 ! USE_MPI

--- a/src/surfacehop.F90
+++ b/src/surfacehop.F90
@@ -3,7 +3,7 @@
 module mod_sh
    use mod_const, only: DP
    use mod_array_size, only: NSTMAX, NTRAJMAX
-   use mod_utils, only: abinerror, print_xyz_arrays
+   use mod_utils, only: abinerror
    use mod_sh_integ
    implicit none
    private

--- a/src/tera_mpi_api.F90
+++ b/src/tera_mpi_api.F90
@@ -436,14 +436,14 @@ contains
 
    subroutine initialize_tc_servers()
       use mod_utils, only: not_compiled_with
-      call not_compiled_with('MPI', 'initialize_tc_servers')
+      call not_compiled_with('MPI')
    end subroutine initialize_tc_servers
 
    subroutine initialize_terachem_interface(tc_server_name)
       use mod_utils, only: not_compiled_with
       character(len=*), intent(in) :: tc_server_name
       write (*, *) 'TC_SERVER_NAME=', tc_server_name
-      call not_compiled_with('MPI', 'initialize_terachem_interface')
+      call not_compiled_with('MPI')
    end subroutine initialize_terachem_interface
 
 ! USE_MPI

--- a/src/transform.F90
+++ b/src/transform.F90
@@ -480,7 +480,7 @@ contains
 
       equant = equantx + equanty + equantz
 
-      if (idebug == 1) then
+      if (idebug > 0) then
          write (*, *) "Quantum energy in cartesian coordinates"
          write (*, *) equantx, equanty, equantz, equant
          write (*, *) "Cartesian coordinates"
@@ -533,7 +533,7 @@ contains
 
       equant = equantx + equanty + equantz
 
-      if (idebug == 1) then
+      if (idebug > 0) then
          write (*, *) 'omegas', (omega(iw), iw=1, nwalk)
          write (*, *) "Quantum energy in normal modes coordinates"
          write (*, *) equantx, equanty, equantz, equant

--- a/src/utils.F90
+++ b/src/utils.F90
@@ -7,12 +7,15 @@ module mod_utils
 contains
 
    real(DP) function get_distance(x, y, z, at1, at2, iw)
+      use mod_error, only: fatal_error
       real(DP), intent(in) :: x(:, :), y(:, :), z(:, :)
       integer, intent(in) :: at1, at2, iw
+      character(len=*), parameter :: error_msg = 'Atom indices in get_distance() must be unique'
       real(DP) :: r
+
       if (at1 == at2) then
-         write (*, *) 'ERROR: Atom indices in function get_distance are not unique!'
-         call abinerror('get_distance')
+         call fatal_error(__FILE__, __LINE__, error_msg)
+         return
       end if
 
       r = (x(at1, iw) - x(at2, iw))**2
@@ -24,15 +27,17 @@ contains
 
    real(DP) function get_angle(x, y, z, at1, at2, at3, iw)
       use mod_const, only: PI
+      use mod_error, only: fatal_error
       real(DP), intent(in) :: x(:, :), y(:, :), z(:, :)
       integer, intent(in) :: iw
       real(DP) :: vec1x, vec1y, vec1z
       real(DP) :: vec2x, vec2y, vec2z
       integer :: at1, at2, at3
+      character(len=*), parameter :: error_msg = 'Atom indices in get_angle() must be unique'
 
       if (at1 == at2 .or. at1 == at3 .or. at2 == at3) then
-         write (*, *) 'ERROR: Atom indices in function get_angle are not unique!'
-         call abinerror('get_angle')
+         call fatal_error(__FILE__, __LINE__, error_msg)
+         return
       end if
 
       vec1x = x(at1, iw) - x(at2, iw)
@@ -77,6 +82,7 @@ contains
       sign = norm1x * vec3x + norm1y * vec3y + norm1z * vec3z
       ! TODO: Refactor, make more intermediate results, e.g.
       ! norms of the normal vectors.
+      ! TODO: Add error handling for malformed dihedral angles to prevent division by zero
       get_dihedral = 180 / pi * acos( &
              & (norm1x * norm2x + norm1y * norm2y + norm1z * norm2z) / &
              & (sqrt(norm1x**2 + norm1y**2 + norm1z**2) * sqrt(norm2x**2 + norm2y**2 + norm2z**2)) &

--- a/src/utils.F90
+++ b/src/utils.F90
@@ -95,7 +95,7 @@ contains
    function sanitize_string(string) result(return_string)
       character(len=*), intent(in) :: string
       character(len=len(string)) :: return_string
-      character(len=len(string)+200) :: error_msg
+      character(len=len(string) + 200) :: error_msg
       character(len=1) :: ch
       integer :: c, i
 
@@ -271,7 +271,7 @@ contains
 
    subroutine file_exists_or_exit(fname)
       character(len=*), intent(in) :: fname
-      character(len=len(fname)+30) :: error_msg
+      character(len=len(fname) + 30) :: error_msg
       logical :: exists
       inquire (file=trim(fname), exist=exists)
       if (.not. exists) then

--- a/src/utils.F90
+++ b/src/utils.F90
@@ -197,9 +197,11 @@ contains
    end function toupper
 
    subroutine not_compiled_with(feature, caller)
+      use mod_error, only: fatal_error
       character(len=*), intent(in) :: feature, caller
-      write (*, *) 'ERROR: ABIN was not compiled with '//feature
-      call abinerror(caller)
+      character(:), allocatable :: error_msg
+      error_msg = 'ABIN was not compiled with '//feature
+      call fatal_error(__FILE__, __LINE__, error_msg)
    end subroutine not_compiled_with
 
    ! TODO: Maybe move this into a separate error handling module,

--- a/src/utils.F90
+++ b/src/utils.F90
@@ -269,15 +269,6 @@ contains
       end if
    end subroutine archive_file
 
-   subroutine debug_output(msg)
-      ! See SO about fortran std units
-      ! https://stackoverflow.com/questions/8508590/standard-input-and-output-units-in-fortran-90#8508757
-      use iso_fortran_env, only: ERROR_UNIT
-      character(len=*), intent(in) :: msg
-      write (ERROR_UNIT, '(A)') msg
-      call flush (ERROR_UNIT)
-   end subroutine debug_output
-
    subroutine file_exists_or_exit(fname)
       character(len=*), intent(in) :: fname
       character(len=len(fname)+30) :: error_msg

--- a/tests/PILE/input.in
+++ b/tests/PILE/input.in
@@ -11,6 +11,8 @@ irandom=131313,
 nwrite=1,
 nwritex=1,
 nrest=1,
+
+idebug=2
 /
 
 &nhcopt

--- a/tests/WITHOUT_CP2K/ERROR.ref
+++ b/tests/WITHOUT_CP2K/ERROR.ref
@@ -1,1 +1,1 @@
-ERROR: ABIN was not compiled with internal CP2K interface
+ERROR in utils.F90: ABIN was not compiled with internal CP2K interface

--- a/tests/WITHOUT_CP2K/ERROR.ref
+++ b/tests/WITHOUT_CP2K/ERROR.ref
@@ -1,1 +1,1 @@
-ERROR at utils.F90:204 ABIN was not compiled with internal CP2K interface      
+ERROR: ABIN was not compiled with internal CP2K interface

--- a/tests/WITHOUT_CP2K/ERROR.ref
+++ b/tests/WITHOUT_CP2K/ERROR.ref
@@ -1,2 +1,1 @@
- FATAL ERROR encountered in subroutine: init_cp2k
- Check standard output for further information.
+ERROR at utils.F90:204 ABIN was not compiled with internal CP2K interface      

--- a/tests/WITHOUT_FFTW/ERROR.ref
+++ b/tests/WITHOUT_FFTW/ERROR.ref
@@ -1,4 +1,3 @@
- FATAL ERROR encountered in subroutine: fftw_normalmodes_init
- Check standard output for further information.
+ERROR at utils.F90:204 ABIN was not compiled with FFTW library      
  FATAL ERROR encountered in subroutine: pile_init
  Check standard output for further information.

--- a/tests/WITHOUT_FFTW/ERROR.ref
+++ b/tests/WITHOUT_FFTW/ERROR.ref
@@ -1,3 +1,3 @@
-ERROR at utils.F90:204 ABIN was not compiled with FFTW library      
+ERROR: ABIN was not compiled with FFTW library
  FATAL ERROR encountered in subroutine: pile_init
  Check standard output for further information.

--- a/tests/WITHOUT_FFTW/ERROR.ref
+++ b/tests/WITHOUT_FFTW/ERROR.ref
@@ -1,3 +1,3 @@
-ERROR: ABIN was not compiled with FFTW library
+ERROR in utils.F90: ABIN was not compiled with FFTW library
  FATAL ERROR encountered in subroutine: pile_init
  Check standard output for further information.

--- a/tests/WITHOUT_MPI/ERROR.ref
+++ b/tests/WITHOUT_MPI/ERROR.ref
@@ -1,1 +1,1 @@
-ERROR: ABIN was not compiled with MPI
+ERROR in utils.F90: ABIN was not compiled with MPI

--- a/tests/WITHOUT_MPI/ERROR.ref
+++ b/tests/WITHOUT_MPI/ERROR.ref
@@ -1,1 +1,1 @@
-ERROR at utils.F90:204 ABIN was not compiled with MPI      
+ERROR: ABIN was not compiled with MPI

--- a/tests/WITHOUT_MPI/ERROR.ref
+++ b/tests/WITHOUT_MPI/ERROR.ref
@@ -1,2 +1,1 @@
- FATAL ERROR encountered in subroutine: initialize_terachem_interface
- Check standard output for further information.
+ERROR at utils.F90:204 ABIN was not compiled with MPI      

--- a/tests/WITHOUT_PLUMED/ERROR.ref
+++ b/tests/WITHOUT_PLUMED/ERROR.ref
@@ -1,1 +1,1 @@
-ERROR at utils.F90:204 ABIN was not compiled with PLUMED      
+ERROR: ABIN was not compiled with PLUMED

--- a/tests/WITHOUT_PLUMED/ERROR.ref
+++ b/tests/WITHOUT_PLUMED/ERROR.ref
@@ -1,1 +1,1 @@
-ERROR: ABIN was not compiled with PLUMED
+ERROR in utils.F90: ABIN was not compiled with PLUMED

--- a/tests/WITHOUT_PLUMED/ERROR.ref
+++ b/tests/WITHOUT_PLUMED/ERROR.ref
@@ -1,2 +1,1 @@
- FATAL ERROR encountered in subroutine: plumed_init
- Check standard output for further information.
+ERROR at utils.F90:204 ABIN was not compiled with PLUMED      

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -1,4 +1,5 @@
 # Makefile for ABIN Unit Tests
+#
 # Should be invoked from top level Makefile,
 # which defines certain variables used here,
 # namely path to PFUNIT library
@@ -19,11 +20,13 @@ endif
 # NOTE: $(LIBS) are defined in the root Makefile
 
 utils_TESTS := test_utils.pf
-utils_REGISTRY :=
-utils_OTHER_SOURCES :=
 utils_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}
-utils_OTHER_INCS :=
+utils_OTHER_SRCS := throw_with_pfunit.F90
+utils_EXTRA_USE := throw_with_pfunit_mod
+utils_EXTRA_INITIALIZE := initialize_throw
 $(eval $(call make_pfunit_test,utils))
+
+utils_driver.o: throw_with_pfunit.o
 
 plumed_TESTS := test_plumed.pf
 plumed_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -30,10 +30,16 @@ utils_driver.o: throw_with_pfunit.o
 
 plumed_TESTS := test_plumed.pf
 plumed_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}
+plumed_OTHER_SRCS := throw_with_pfunit.F90
+plumed_EXTRA_USE := throw_with_pfunit_mod
+plumed_EXTRA_INITIALIZE := initialize_throw
 $(eval $(call make_pfunit_test,plumed))
 
 fftw_TESTS := test_fftw.pf
 fftw_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}
+fftw_OTHER_SRCS := throw_with_pfunit.F90
+fftw_EXTRA_USE := throw_with_pfunit_mod
+fftw_EXTRA_INITIALIZE := initialize_throw
 $(eval $(call make_pfunit_test,fftw))
 
 all : utils plumed fftw

--- a/unit_tests/test_fftw.pf
+++ b/unit_tests/test_fftw.pf
@@ -12,13 +12,13 @@ contains
 #ifdef USE_FFTW
 
    ! This routine is called automatically before each test.
-   @before(ifdef=USE_FFTW)
+   @before
    subroutine setup()
       call fftw_normalmodes_init(NBEADS)
    end subroutine setup
 
    ! This routine is called automatically after each test.
-   @after(ifdef=USE_FFTW)
+   @after
    subroutine teardown()
       call fftw_normalmodes_finalize()
    end subroutine teardown
@@ -42,12 +42,23 @@ contains
 
 #else
 
+   @before
+   subroutine setup()
+   end subroutine setup
+
+   @after
+   subroutine teardown()
+      ! This one is must be a no-op, so no exception should be raised
+      call fftw_normalmodes_finalize()
+   end subroutine teardown
+
    @test(ifndef=USE_FFTW)
    subroutine test_not_compiled_with_fftw()
       use, intrinsic :: iso_c_binding, only: C_DOUBLE, C_DOUBLE_COMPLEX
       complex(C_DOUBLE_COMPLEX), dimension(1) :: normal_modes
       real(C_DOUBLE), dimension(1) :: xyz
       integer :: nbeads
+
       call fftw_normalmodes_init(nbeads)
       @assertExceptionRaised('ABIN was not compiled with FFTW library')
 
@@ -56,9 +67,6 @@ contains
 
       call dft_cart2normalmode(xyz, normal_modes)
       @assertExceptionRaised('ABIN was not compiled with FFTW library')
-
-      ! This one is must be a no-op, so no exception should be raised
-      call fftw_normalmodes_finalize()
    end subroutine test_not_compiled_with_fftw
 
 #endif

--- a/unit_tests/test_fftw.pf
+++ b/unit_tests/test_fftw.pf
@@ -12,19 +12,18 @@ contains
 #ifdef USE_FFTW
 
    ! This routine is called automatically before each test.
-   @before
+   @before(ifdef=USE_FFTW)
    subroutine setup()
       call fftw_normalmodes_init(NBEADS)
    end subroutine setup
 
    ! This routine is called automatically after each test.
-   @after
+   @after(ifdef=USE_FFTW)
    subroutine teardown()
       call fftw_normalmodes_finalize()
    end subroutine teardown
 
-
-   ! Here we just test we can initialize and finalize FFTW module 
+   ! Here we just test we can initialize and finalize FFTW module
    ! without dying, no assertions here.
    @test(ifdef=USE_FFTW)
    subroutine test_fftw_init_and_finalize()
@@ -40,6 +39,27 @@ contains
    @disable
    subroutine test_dft_cart2normalmode()
    end subroutine test_dft_cart2normalmode
+
+#else
+
+   @test(ifndef=USE_FFTW)
+   subroutine test_not_compiled_with_fftw()
+      use, intrinsic :: iso_c_binding, only: C_DOUBLE, C_DOUBLE_COMPLEX
+      complex(C_DOUBLE_COMPLEX), dimension(1) :: normal_modes
+      real(C_DOUBLE), dimension(1) :: xyz
+      integer :: nbeads
+      call fftw_normalmodes_init(nbeads)
+      @assertExceptionRaised('ABIN was not compiled with FFTW library')
+
+      call dft_normalmode2cart(normal_modes, xyz)
+      @assertExceptionRaised('ABIN was not compiled with FFTW library')
+
+      call dft_cart2normalmode(xyz, normal_modes)
+      @assertExceptionRaised('ABIN was not compiled with FFTW library')
+
+      ! This one is must be a no-op, so no exception should be raised
+      call fftw_normalmodes_finalize()
+   end subroutine test_not_compiled_with_fftw
 
 #endif
 end module test_fftw

--- a/unit_tests/test_plumed.pf
+++ b/unit_tests/test_plumed.pf
@@ -18,7 +18,7 @@ contains
 #ifdef USE_PLUMED
 
    ! This routine is called automatically before each test.
-   @before
+   @before(ifdef=USE_PLUMED)
    subroutine setup()
       use mod_general, only: natom, nwalk, dt0, it
       use mod_system, only: am
@@ -49,7 +49,7 @@ contains
    end subroutine setup
 
    ! This routine is called automatically after each test.
-   @after
+   @after(ifdef=USE_PLUMED)
    subroutine teardown()
       use mod_system, only: am
       deallocate (am)
@@ -65,7 +65,6 @@ contains
       ! defined in src/plumed.F90.
       call finalize_plumed()
    end subroutine teardown
-
 
    ! Here we just test we can initialize and finalize PLUMED without dying,
    ! no assertions here.
@@ -326,6 +325,20 @@ contains
       open (iunit, file=PLUMED_HILLS_FILE)
       close (iunit, status='delete')
    end subroutine test_force_metad
+
+#else
+   @test(ifndef=USE_PLUMED)
+   subroutine test_not_compiled_with_plumed()
+      real(DP) :: eclas
+      call plumed_init()
+      @assertExceptionRaised('ABIN was not compiled with PLUMED')
+
+      call force_plumed(x, y, z, fx, fy, fz, eclas)
+      @assertExceptionRaised('ABIN was not compiled with PLUMED')
+
+      ! This one is must be a no-op, so no exception should be raised
+      call finalize_plumed()
+   end subroutine test_not_compiled_with_plumed
 
 #endif
 end module test_plumed

--- a/unit_tests/test_plumed.pf
+++ b/unit_tests/test_plumed.pf
@@ -18,7 +18,7 @@ contains
 #ifdef USE_PLUMED
 
    ! This routine is called automatically before each test.
-   @before(ifdef=USE_PLUMED)
+   @before
    subroutine setup()
       use mod_general, only: natom, nwalk, dt0, it
       use mod_system, only: am
@@ -49,7 +49,7 @@ contains
    end subroutine setup
 
    ! This routine is called automatically after each test.
-   @after(ifdef=USE_PLUMED)
+   @after
    subroutine teardown()
       use mod_system, only: am
       deallocate (am)
@@ -327,6 +327,16 @@ contains
    end subroutine test_force_metad
 
 #else
+   @before
+   subroutine setup()
+   end subroutine setup
+
+   @after
+   subroutine teardown()
+      ! This one is must be a no-op, so no exception should be raised
+      call finalize_plumed()
+   end subroutine teardown
+
    @test(ifndef=USE_PLUMED)
    subroutine test_not_compiled_with_plumed()
       real(DP) :: eclas
@@ -335,9 +345,6 @@ contains
 
       call force_plumed(x, y, z, fx, fy, fz, eclas)
       @assertExceptionRaised('ABIN was not compiled with PLUMED')
-
-      ! This one is must be a no-op, so no exception should be raised
-      call finalize_plumed()
    end subroutine test_not_compiled_with_plumed
 
 #endif

--- a/unit_tests/test_utils.pf
+++ b/unit_tests/test_utils.pf
@@ -26,7 +26,7 @@ contains
 
       ! Notice that we also left-adjust the string.
       @assertEqual("12abc-._ ", tolower("   12AbC-._ "))
-   
+
    end subroutine test_tolower
 
    @test
@@ -34,7 +34,7 @@ contains
 
       ! Notice that we also left-adjust the string.
       @assertEqual("ABC-._123", toupper("  AbC-._123 "))
-   
+
    end subroutine test_toupper
 
    @test
@@ -42,11 +42,10 @@ contains
       character(len=*), parameter :: fstring = " string "
       @assertEqual("string"//char(0), c_string(fstring), "c_string(' string ')")
 
-      @assertEqual(len(fstring)+1, len(c_string(fstring)), "len(cstring) == len(fstring)+1")
+      @assertEqual(len(fstring) + 1, len(c_string(fstring)), "len(cstring) == len(fstring)+1")
 
-      @assertEqual(6+1, len_trim(c_string(fstring)), "len_trim(c_string) = len(trim(adjustl(fstring)))+1")
+      @assertEqual(6 + 1, len_trim(c_string(fstring)), "len_trim(c_string) = len(trim(adjustl(fstring)))+1")
    end subroutine test_c_string
-
 
    @test
    subroutine test_normalize_atom_name()
@@ -67,7 +66,7 @@ contains
       integer, parameter :: NATOM = 4
       character(len=2) :: names(NATOM)
       ! Note: names must already be normalized
-      names = (/'He', 'C ', 'C ', 'Cl' /)
+      names = (/'He', 'C ', 'C ', 'Cl'/)
       @assertEqual(1, count_atoms_by_name(names, 'HE', NATOM))
       @assertEqual(2, count_atoms_by_name(names, 'c ', NATOM))
       @assertEqual(1, count_atoms_by_name(names, 'Cl', NATOM))
@@ -76,29 +75,29 @@ contains
    @test
    subroutine test_get_distance()
       ! Cartesian distance between two atoms
-      real(DP) :: x(2,2), y(2,2), z(2,2)
+      real(DP) :: x(2, 2), y(2, 2), z(2, 2)
       integer :: iw
       real(DP) :: dist
 
-      x(:,1) = [0.0d0, 1.0d0]
-      y(:,1) = [2.0d0, 2.0d0]
-      z(:,1) = [3.0d0, 3.0d0]
+      x(:, 1) = [0.0D0, 1.0D0]
+      y(:, 1) = [2.0D0, 2.0D0]
+      z(:, 1) = [3.0D0, 3.0D0]
 
       iw = 1
       dist = get_distance(x, y, z, 1, 2, iw)
-      @assertEqual(1.0d0, dist, "get_distance1")
+      @assertEqual(1.0D0, dist, "get_distance1")
 
       ! Should be invariant with respect to the atom order
       dist = get_distance(x, y, z, 2, 1, iw)
-      @assertEqual(1.0d0, dist, "get_distance2")
+      @assertEqual(1.0D0, dist, "get_distance2")
 
       iw = 2
       ! Pascal triangle, 3^2 + 4^2 = 5^2
-      x(:,2) = [1.0d0, 1.0d0]
-      y(:,2) = [1.0d0, 4.0d0]
-      z(:,2) = [4.0d0, 0.0d0]
+      x(:, 2) = [1.0D0, 1.0D0]
+      y(:, 2) = [1.0D0, 4.0D0]
+      z(:, 2) = [4.0D0, 0.0D0]
       dist = get_distance(x, y, z, 1, 2, iw)
-      @assertEqual(5.0d0, dist, "get_distance3")
+      @assertEqual(5.0D0, dist, "get_distance3")
 
       ! Should error when non-unique atom indeces are passed in
       dist = get_distance(x, y, z, 1, 1, iw)
@@ -107,41 +106,41 @@ contains
 
    @test
    subroutine test_get_angle()
-      real(DP) :: x(3,2), y(3,2), z(3,2)
+      real(DP) :: x(3, 2), y(3, 2), z(3, 2)
       integer :: iw
       real(DP) :: ang
 
-      x(:,1) = [0.0d0, 0.0d0, 0.0d0 ]
-      y(:,1) = [1.0d0, 0.0d0, 0.0d0 ]
-      z(:,1) = [0.0d0, 0.0d0, 1.0d0 ]
+      x(:, 1) = [0.0D0, 0.0D0, 0.0D0]
+      y(:, 1) = [1.0D0, 0.0D0, 0.0D0]
+      z(:, 1) = [0.0D0, 0.0D0, 1.0D0]
       iw = 1
 
       ang = get_angle(x, y, z, 1, 2, 3, iw)
-      @assertEqual(90.0d0, ang, "get_angle_90")
+      @assertEqual(90.0D0, ang, "get_angle_90")
 
       ! Test atom order invariance
       ang = get_angle(x, y, z, 3, 2, 1, iw)
-      @assertEqual(90.0d0, ang, "get_angle_90_2")
+      @assertEqual(90.0D0, ang, "get_angle_90_2")
 
       ang = get_angle(x, y, z, 2, 1, 3, iw)
       ! TODO: instead of hardcoding this imprecise value,
       ! specify a tolerance for 45.0d0. Need to figure out how.
-      @assertEqual(45.000000000000007d0, ang, "get_angle_45")
+      @assertEqual(45.000000000000007D0, ang, "get_angle_45")
 
       iw = 2
-      x(:,2) = [1.0d0, 0.0d0, -1.0d0 ]
-      y(:,2) = [2.0d0, 2.0d0, 2.0d0 ]
-      z(:,2) = [3.0d0, 3.0d0, 3.0d0 ]
+      x(:, 2) = [1.0D0, 0.0D0, -1.0D0]
+      y(:, 2) = [2.0D0, 2.0D0, 2.0D0]
+      z(:, 2) = [3.0D0, 3.0D0, 3.0D0]
       ang = get_angle(x, y, z, 1, 2, 3, iw)
-      @assertEqual(180.0d0, ang, "get_angle_180")
+      @assertEqual(180.0D0, ang, "get_angle_180")
 
       ang = get_angle(x, y, z, 3, 2, 1, iw)
-      @assertEqual(180.0d0, ang, "get_angle_180_2")
+      @assertEqual(180.0D0, ang, "get_angle_180_2")
 
       ang = get_angle(x, y, z, 2, 1, 3, iw)
-      @assertEqual(0.0d0, ang, "get_angle_0")
+      @assertEqual(0.0D0, ang, "get_angle_0")
       ang = get_angle(x, y, z, 2, 3, 1, iw)
-      @assertEqual(0.0d0, ang, "get_angle_0_2")
+      @assertEqual(0.0D0, ang, "get_angle_0_2")
 
       ! Should error when non-unique atom indeces are passed in
       ang = get_angle(x, y, z, 3, 1, 1, iw)
@@ -151,38 +150,38 @@ contains
 
    @test
    subroutine test_get_dihedral()
-      real(DP) :: x(4,2), y(4,2), z(4,2)
+      real(DP) :: x(4, 2), y(4, 2), z(4, 2)
       real(DP) :: shiftdih
       integer :: iw
       real(DP) :: ang
 
       ! Dihedral values between -180 -- 180 degrees
-      shiftdih = 0.0d0
+      shiftdih = 0.0D0
 
-      x(:,1) = [1.0d0, 1.0d0, 0.0d0, 0.0d0 ]
-      y(:,1) = [1.0d0, 0.0d0, 0.0d0, 0.0d0 ]
-      z(:,1) = [0.0d0, 0.0d0, 0.0d0, 1.0d0 ]
+      x(:, 1) = [1.0D0, 1.0D0, 0.0D0, 0.0D0]
+      y(:, 1) = [1.0D0, 0.0D0, 0.0D0, 0.0D0]
+      z(:, 1) = [0.0D0, 0.0D0, 0.0D0, 1.0D0]
 
       iw = 1
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
-      @assertEqual(-90.0d0, ang, "get_dihedral_-90")
+      @assertEqual(-90.0D0, ang, "get_dihedral_-90")
 
       ang = get_dihedral(x, y, z, 1, 3, 2, 4, iw, shiftdih)
-      @assertEqual(90.0d0, ang, "get_dihedral_90")
+      @assertEqual(90.0D0, ang, "get_dihedral_90")
 
-      x(:,2) = [1.0d0, 1.0d0, 0.0d0, 0.0d0 ]
-      y(:,2) = [1.0d0, 0.0d0, 0.0d0, -1.0d0 ]
-      z(:,2) = [0.0d0, 0.0d0, 0.0d0, 0.0d0 ]
+      x(:, 2) = [1.0D0, 1.0D0, 0.0D0, 0.0D0]
+      y(:, 2) = [1.0D0, 0.0D0, 0.0D0, -1.0D0]
+      z(:, 2) = [0.0D0, 0.0D0, 0.0D0, 0.0D0]
 
       iw = 2
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
-      @assertEqual(180.0d0, ang, "get_dihedral_180")
+      @assertEqual(180.0D0, ang, "get_dihedral_180")
 
-      x(:,2) = [1.0d0, 1.0d0, 0.0d0, 0.0d0 ]
-      y(:,2) = [1.0d0, 0.0d0, 0.0d0, 1.0d0 ]
-      z(:,2) = [0.0d0, 0.0d0, 0.0d0, 0.0d0 ]
+      x(:, 2) = [1.0D0, 1.0D0, 0.0D0, 0.0D0]
+      y(:, 2) = [1.0D0, 0.0D0, 0.0D0, 1.0D0]
+      z(:, 2) = [0.0D0, 0.0D0, 0.0D0, 0.0D0]
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
-      @assertEqual(0.0d0, ang, "get_dihedral_0")
+      @assertEqual(0.0D0, ang, "get_dihedral_0")
 
       ! TODO: Should error when non-unique atom indeces are passed in
       !ang = get_dihedral(x, y, z, 1, 1, 3, 4, iw, shiftdih)
@@ -190,41 +189,40 @@ contains
 
    end subroutine test_get_dihedral
 
-
    @test
    subroutine test_shifted_dihedral()
-      real(DP) :: x(4,2), y(4,2), z(4,2)
+      real(DP) :: x(4, 2), y(4, 2), z(4, 2)
       real(DP) :: shiftdih
       integer :: iw
       real(DP) :: ang
 
       ! Dihedral values between 0 - 360 degrees
-      shiftdih = 360.0d0
+      shiftdih = 360.0D0
 
-      x(:,1) = [1.0d0, 1.0d0, 0.0d0, 0.0d0 ]
-      y(:,1) = [1.0d0, 0.0d0, 0.0d0, 0.0d0 ]
-      z(:,1) = [0.0d0, 0.0d0, 0.0d0, 1.0d0 ]
+      x(:, 1) = [1.0D0, 1.0D0, 0.0D0, 0.0D0]
+      y(:, 1) = [1.0D0, 0.0D0, 0.0D0, 0.0D0]
+      z(:, 1) = [0.0D0, 0.0D0, 0.0D0, 1.0D0]
 
       iw = 1
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
-      @assertEqual(270.0d0, ang, "get_dihedral_270")
+      @assertEqual(270.0D0, ang, "get_dihedral_270")
 
       ang = get_dihedral(x, y, z, 1, 3, 2, 4, iw, shiftdih)
-      @assertEqual(90.0d0, ang, "get_dihedral_90")
+      @assertEqual(90.0D0, ang, "get_dihedral_90")
 
-      x(:,2) = [1.0d0, 1.0d0, 0.0d0, 0.0d0 ]
-      y(:,2) = [1.0d0, 0.0d0, 0.0d0, -1.0d0 ]
-      z(:,2) = [0.0d0, 0.0d0, 0.0d0, 0.0d0 ]
+      x(:, 2) = [1.0D0, 1.0D0, 0.0D0, 0.0D0]
+      y(:, 2) = [1.0D0, 0.0D0, 0.0D0, -1.0D0]
+      z(:, 2) = [0.0D0, 0.0D0, 0.0D0, 0.0D0]
 
       iw = 2
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
-      @assertEqual(180.0d0, ang, "get_dihedral_180")
+      @assertEqual(180.0D0, ang, "get_dihedral_180")
 
-      x(:,2) = [1.0d0, 1.0d0, 0.0d0, 0.0d0 ]
-      y(:,2) = [1.0d0, 0.0d0, 0.0d0, 1.0d0 ]
-      z(:,2) = [0.0d0, 0.0d0, 0.0d0, 0.0d0 ]
+      x(:, 2) = [1.0D0, 1.0D0, 0.0D0, 0.0D0]
+      y(:, 2) = [1.0D0, 0.0D0, 0.0D0, 1.0D0]
+      z(:, 2) = [0.0D0, 0.0D0, 0.0D0, 0.0D0]
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
-      @assertEqual(0.0d0, ang, "get_dihedral_0")
+      @assertEqual(0.0D0, ang, "get_dihedral_0")
 
    end subroutine test_shifted_dihedral
 

--- a/unit_tests/test_utils.pf
+++ b/unit_tests/test_utils.pf
@@ -91,6 +91,10 @@ contains
       z(:,2) = [4.0d0, 0.0d0]
       dist = get_distance(x, y, z, 1, 2, iw)
       @assertEqual(5.0d0, dist, "get_distance3")
+
+      ! Should error when non-unique atom indeces are passed in
+      dist = get_distance(x, y, z, 1, 1, iw)
+      @assertExceptionRaised('Atom indices in get_distance() must be unique')
    end subroutine test_get_distance
 
    @test
@@ -131,6 +135,10 @@ contains
       ang = get_angle(x, y, z, 2, 3, 1, iw)
       @assertEqual(0.0d0, ang, "get_angle_0_2")
 
+      ! Should error when non-unique atom indeces are passed in
+      ang = get_angle(x, y, z, 3, 1, 1, iw)
+      @assertExceptionRaised('Atom indices in get_angle() must be unique')
+
    end subroutine test_get_angle
 
    @test
@@ -167,6 +175,10 @@ contains
       z(:,2) = [0.0d0, 0.0d0, 0.0d0, 0.0d0 ]
       ang = get_dihedral(x, y, z, 1, 2, 3, 4, iw, shiftdih)
       @assertEqual(0.0d0, ang, "get_dihedral_0")
+
+      ! TODO: Should error when non-unique atom indeces are passed in
+      !ang = get_dihedral(x, y, z, 1, 1, 3, 4, iw, shiftdih)
+      !@assertExceptionRaised('Atom indices in get_dihedral() must be unique')
 
    end subroutine test_get_dihedral
 

--- a/unit_tests/test_utils.pf
+++ b/unit_tests/test_utils.pf
@@ -50,11 +50,16 @@ contains
 
    @test
    subroutine test_normalize_atom_name()
+      character(len=:), allocatable :: dummy
       @assertEqual("H", normalize_atom_name("h"), "h -> H")
       @assertEqual("Cl", normalize_atom_name("cl"), "cl -> Cl")
       @assertEqual("Fe", normalize_atom_name("FE"), "FE -> Fe")
       @assertEqual("H", normalize_atom_name("   h  "), "accepts blanks")
       @assertEqual("Cl", normalize_atom_name(" cl   "), "accepts blanks")
+
+      ! Reject atom names longer then three characters.
+      dummy = normalize_atom_name("HeH")
+      @assertExceptionRaised('Incorrect atom name: "HeH"')
    end subroutine test_normalize_atom_name
 
    @test

--- a/unit_tests/test_utils.pf
+++ b/unit_tests/test_utils.pf
@@ -9,13 +9,16 @@ contains
 
    @test
    subroutine test_sanitize_string()
-      ! NOTE: Sanitize string should exit when
-      ! suspicious character is found, but we currently cannot
-      ! test that. So we only test that it leaves valid strings
-      ! alone, except for applying adjustl on them.
+      character(len=2) :: invalid_input = '$a'
+      ! Sanitize string should exit when
+      ! suspicious character is found.
+      ! Somewhat confusignly, it also applies adjutl()
       @assertEqual("12345abC-._ ", sanitize_string("12345abC-._ "))
 
       @assertEqual("abC-._67890", sanitize_string("  abC-._67890 "))
+
+      invalid_input = sanitize_string(invalid_input)
+      @assertExceptionRaised('Suspicious character "$" in input string "$a"')
    end subroutine test_sanitize_string
 
    @test
@@ -221,17 +224,9 @@ contains
    end subroutine test_shifted_dihedral
 
    @test
-   @disable
-   subroutine test_invalid_angle()
-      real(DP) :: x(3,1), y(3,1), z(3,1)
-      real(DP) :: ang
-      integer :: iw
-      x = 0.0d0; y = 0.0d0; z = 0.0d0
-      iw = 1
-      ! TODO: Test that we fail gracefully if the atom indeces are not unique.
-      ! We need to replace abinerror in tests
-      ! For now, this test is skipped.
-      ang = get_angle(x, y, z, 1, 1, 1, iw)
-   end subroutine test_invalid_angle
+   subroutine test_file_exists_or_exit()
+      call file_exists_or_exit('CRAZY_FILE')
+      @assertExceptionRaised('Could not find file "CRAZY_FILE"')
+   end subroutine test_file_exists_or_exit
 
 end module test_utils

--- a/unit_tests/throw_with_pfunit.F90
+++ b/unit_tests/throw_with_pfunit.F90
@@ -1,0 +1,35 @@
+module throw_with_pfunit_mod
+   ! This is a method from ABIN, see src/error.F90
+   use mod_error, only: set_throw_method
+   implicit none
+   private
+
+   public :: throw
+   public :: initialize_throw
+
+contains
+
+   subroutine throw(file_name, line_number, message)
+      use funit, only: SourceLocation
+      use funit, only: pFUnit_throw => throw
+      character(len=*), intent(in) :: file_name
+      integer, intent(in) :: line_number
+      character(len=*), optional, intent(in) :: message
+
+      character(len=:), allocatable :: message_
+
+      if (present(message)) then
+         message_ = message
+      else
+         message_ = '<no message>'
+      end if
+      call pFUnit_throw(message_, SourceLocation(file_name, line_number))
+
+   end subroutine throw
+
+   subroutine initialize_throw()
+      call set_throw_method(throw)
+   end subroutine initialize_throw
+
+   
+end module throw_with_pfunit_mod

--- a/unit_tests/throw_with_pfunit.F90
+++ b/unit_tests/throw_with_pfunit.F90
@@ -9,6 +9,8 @@ module throw_with_pfunit_mod
 
 contains
 
+   ! This routine replaces src/error.F90:fatal_error()
+   ! so that we can catch exceptions in the unit tests.
    subroutine throw(file_name, line_number, message)
       use funit, only: SourceLocation
       use funit, only: pFUnit_throw => throw

--- a/unit_tests/throw_with_pfunit.F90
+++ b/unit_tests/throw_with_pfunit.F90
@@ -1,6 +1,6 @@
 module throw_with_pfunit_mod
    ! This is a method from ABIN, see src/error.F90
-   use mod_error, only: set_throw_method
+   use mod_error, only: set_error_method
    implicit none
    private
 
@@ -14,21 +14,14 @@ contains
       use funit, only: pFUnit_throw => throw
       character(len=*), intent(in) :: file_name
       integer, intent(in) :: line_number
-      character(len=*), optional, intent(in) :: message
+      character(len=*), intent(in) :: message
 
-      character(len=:), allocatable :: message_
-
-      if (present(message)) then
-         message_ = message
-      else
-         message_ = '<no message>'
-      end if
-      call pFUnit_throw(message_, SourceLocation(file_name, line_number))
+      call pFUnit_throw(message, SourceLocation(file_name, line_number))
 
    end subroutine throw
 
    subroutine initialize_throw()
-      call set_throw_method(throw)
+      call set_error_method(throw)
    end subroutine initialize_throw
 
    


### PR DESCRIPTION
Here we tentatively refactor the error handling in ABIN, with the ultimate goal of replacing `abinerror`. 

The main purpose of this refactor is to allow the unit tests to test for error conditions. This is currently not possible since calling `abinerror()` unconditionally stops the program, thus disrupting the test suite. To solve that we add a bit of misdirection in `src/error.F90`. Essentially, we allow pFUnit to swap out our error handler subroutine with its own, which then allows checking assertions in unit tests. This swapping occurs via the `set_error_method` in `unit_tests/throw_with_pfunit.F90`.

The new default error handler is called `fatal_error()` and should be used instead of `abinerror`. I converted only a couple of instance for now, and if this all work, I will convert the rest in a separate PR. 

As an added bonus, the new fatal_error takes different arguments from `abinerror`. It takes the file name, line number, and error message. The first two arguments can be conveniently provided via preprocessor-defined constants `__FILENAME__` and `__LINE__`. This way, we can provide the exact location in the code where the error occurred (and the cost of slightly more verbose code). That's pretty cool! :tada:  I am open for discussion about how the errors should be phrased exactly so that it's clear. The format for now resembles how e.g. gfortran prints errors. 