### PR TITLE
Support -V/--version command line options.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,11 @@ Read through the script first to see what it does (it's not long, I promise).
 It is useful especially if you use VIM as your text editor, as it sets it up to use our code style rules.
 If you use a different editor, we welcome if you contribute your config files!
 
-The script also installs `fprettify` that we use to automatically format our code (needs a `python3` environment).
-The script tries to use `pip3` to install it.
-If you use a different Python package manager you should install `fprettify` manually.
+You also should install `fprettify`, which is a Python program that we use for autoformatting the Fortran code. Due to a large variability of Python installation options and environments, we do not try to install it automatically. For example, you can use `pip` (or `pip3` if your default is Python2). 
+
+```sh
+pip install --upgrade fprettify
+```
 
 ### Install dev dependencies
 
@@ -35,6 +37,7 @@ Here's a quick summary of our code style that we try to adhere to:
 module mod_my_module
   private
   integer :: public_var
+  integer :: private_var
   public :: public_var
   public :: public_subroutine
 contains
@@ -59,7 +62,7 @@ Here's a quick summary of our formatting style, as it is defined in `.fprettify.
  - use capital letters only for defined constants (e.g. those from module `mod_const`). We use lower case for everything else.
  - use `snake_case` for naming your subroutines and variables. (not `camelCase`)
  - use C-style relational operators (`< > == /=`) instead of the old FORTRAN style (`.gt. .lt.`)
- - comments should start at the same indenation level as the code they are commnenting.
+ - comments should start at the same indentation level as the code they are commnenting.
     - use an exclamation mark to start a comment
 
 ### Inspecting Git history

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ export
 include make.vars
 
 export SHELL=/bin/bash
-export DATE=`date +"%X %x"`
-
 export COMMIT=NaN
 ifeq ($(shell git --version | cut -b -3),git)
   ifneq ($(shell git status 2>&1 | head -1 | cut -b -5),fatal)

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ F_OBJS := modules.o fortran_interfaces.o error.o utils.o io.o random.o arrays.o 
           shake.o nosehoover.o gle.o transform.o potentials.o estimators.o ekin.o vinit.o plumed.o \
           remd.o force_bound.o water.o force_cp2k.o sh_integ.o surfacehop.o landau_zener.o\
           force_mm.o tera_mpi_api.o force_tera.o force_terash.o force_abin.o en_restraint.o analyze_ext_template.o geom_analysis.o analysis.o \
-          minimizer.o mdstep.o forces.o read_cmdline.o init.o
+          minimizer.o mdstep.o forces.o cmdline.o init.o
 
 C_OBJS := water_interface.o
 
@@ -16,7 +16,7 @@ libabin.a: compile_info.o
 
 # compile_info.F90 must be always recompiled to get the current date/time and git commit
 compile_info.o: compile_info.F90 ${C_OBJS} ${F_OBJS} abin.o
-	$(FC) $(FFLAGS) $(DFLAGS) $(INC) -DCOMPILE_DATE="'${DATE}'" -DGIT_COMMIT="'${COMMIT}'" -c $<
+	$(FC) $(FFLAGS) $(DFLAGS) $(INC) -DGIT_COMMIT="'${COMMIT}'" -c $<
 
 clean:
 	/bin/rm -f *.o *.mod *.gcno *.gcda *.gcov libabin.a $(BIN)

--- a/src/cmdline.F90
+++ b/src/cmdline.F90
@@ -1,11 +1,11 @@
 module mod_cmdline
+   use mod_interfaces, only: print_compile_info
    private
    public :: get_cmdline
 
 contains
 
    subroutine print_help()
-      use mod_interfaces, only: print_compile_info
       implicit none
       integer, dimension(8) :: time_data
 
@@ -18,6 +18,7 @@ contains
       print '(a)', 'cmdline options:'
       print '(a)', ''
       print '(a)', '  -h, --help               print help and exit'
+      print '(a)', '  -V, --version            print version and compiler options'
       print '(a)', '  -i <input_parameters>    default: input.in'
       print '(a)', '  -x <input_coordinates>   default: mini.dat'
       print '(a)', '  -v <input_velocities>    no default'
@@ -39,6 +40,9 @@ contains
          select case (arg)
          case ('-h', '--help')
             call print_help()
+            stop 0
+         case ('-V', '--version')
+            call print_compile_info()
             stop 0
          case ('-i')
             i = i + 1

--- a/src/compile_info.F90
+++ b/src/compile_info.F90
@@ -1,33 +1,34 @@
 ! This file must be recompiled at each compilation
-! to get the current date and timem
-! passed via make parameter (-DCOMPILE_DATE=)
+! to get the current date and time,
+! which are taken from preprocessor constants,
+! and the current Git commit, which is passed in from Makefile.
 subroutine print_compile_info()
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 6
+   use iso_fortran_env, only: compiler_version
    use iso_fortran_env, only: compiler_version, compiler_options
-#endif
+   ! TODO: Decide how we should do versioning
+   character(len=*), parameter :: ABIN_VERSION = '1.1'
 
-   ! DATE and COMMIT are defined and exported in Makefile
-   print*,'Compiled at ', COMPILE_DATE
-   print*,'Git commit '//GIT_COMMIT
-!$ print*,'Compiled with parallel OpenMP support for PIMD.'
+   print '(a)', 'ABIN version '//ABIN_VERSION
+   print '(a, a, 1x, a)', 'Compiled at ', __TIME__, __DATE__
+   print '(a)', 'Git commit '//GIT_COMMIT
+!$ print'(a)', 'Compiled with parallel OpenMP support for PIMD.'
 #ifdef USE_FFTW
-   write (*, *) 'Compiled with FFTW support.'
+   print '(a)', 'Compiled with FFTW support.'
 #endif
 #ifdef USE_CP2K
-   write (*, *) 'Compiled with in-built CP2K interface.'
+   print '(a)', 'Compiled with in-built CP2K interface.'
 #endif
 #ifdef USE_PLUMED
-   write (*, *) 'Compiled with PLUMED (static lib).'
+   print '(a)', 'Compiled with PLUMED (static lib).'
 #endif
 #ifdef USE_MPI
-   write (*, *) 'Compiled with MPI support.'
-   write (*, *) '(used for REMD and direct CP2K and TeraChem interfaces.)'
+   print '(a)', 'Compiled with MPI support.'
+   print '(a)', '(used for REMD and direct CP2K and TeraChem interfaces.)'
 #endif
-   print*,' '
+   print '(a)', ' '
 
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 6
-   print*,'This program was compiled by ', &
-      compiler_version(), ' using the options: '
-   print*,compiler_options()
-#endif
+   print '(a)', 'This program was compiled by:'
+   print '(a)', compiler_version()
+   print '(a)', 'using the compiler options:'
+   print '(a)', compiler_options()
 end subroutine print_compile_info

--- a/src/estimators.F90
+++ b/src/estimators.F90
@@ -252,7 +252,7 @@ end module mod_estimators
 !        dy=yc(2)-yc(1)
 !        dz=zc(2)-zc(1)
 !        r=dx**2+dy**2+dz**2
-!        r=sqrt(r)
+!        r=dsqrt(r)
 !        Vq=0.5*aa*(r-r0)**2
 !      endif
 

--- a/src/force_bound.F90
+++ b/src/force_bound.F90
@@ -41,7 +41,7 @@ contains
       ! calculation of the cluster radius, taken from the center of mass
       do iat = 1, natom
          r = (x(iat, iw) - xcm)**2 + (y(iat, iw) - ycm)**2 + (z(iat, iw) - zcm)**2
-         r = sqrt(r)
+         r = dsqrt(r)
          if (r > rmax .and. names(iat) /= 'H') then
             rmax = r
          end if
@@ -97,7 +97,7 @@ contains
       do iw = 1, nwalk
          do iat = 1, natom
             r = (x(iat, iw) - xcm)**2 + (y(iat, iw) - ycm)**2 + (z(iat, iw) - zcm)**2
-            r = sqrt(r)
+            r = dsqrt(r)
             if (r > rb_sbc .and. names(iat) /= 'H') then
                frb = -kb_sbc * (r - rb_sbc)
                fx(iat, iw) = fx(iat, iw) + frb * (x(iat, iw) - xcm) / (r)

--- a/src/force_mm.F90
+++ b/src/force_mm.F90
@@ -56,7 +56,7 @@ contains
             i2 = inames(iat2)
             if (LJcomb == 'LB') then
                rij = 0.5 * (rmin(i1) + rmin(i2)) * ang
-               epsij = sqrt(eps(i1) * eps(i2))
+               epsij = dsqrt(eps(i1) * eps(i2))
             end if
             BIJ(i1, i2) = 2 * 6 * epsij * rij**6
             AIJ(i1, i2) = 12 * epsij * rij**12
@@ -89,7 +89,7 @@ contains
                i1 = inames(iat1)
                i2 = inames(iat2)
                kLJ = ri3 * (ri3 * AIJ(i1, i2) - BIJ(i1, i2)) * ri
-               kC = q(i1) * q(i2) * sqrt(ri3)
+               kC = q(i1) * q(i2) * dsqrt(ri3)
                fx(iat1, iw) = fx(iat1, iw) + (kLJ + kC) * dx
                fx(iat2, iw) = fx(iat2, iw) - (kLJ + kC) * dx
                fy(iat1, iw) = fy(iat1, iw) + (kLJ + kC) * dy
@@ -97,7 +97,7 @@ contains
                fz(iat1, iw) = fz(iat1, iw) + (kLJ + kC) * dz
                fz(iat2, iw) = fz(iat2, iw) - (kLJ + kC) * dz
                eclas = eclas + ri3 * (ri3 * AIJ(i1, i2) / 12 - BIJ(i1, i2) / 6) / nwalk
-               eclas = eclas + q(i1) * q(i2) / sqrt(r) / nwalk
+               eclas = eclas + q(i1) * q(i2) / dsqrt(r) / nwalk
             end do
          end do
       end do

--- a/src/forces.F90
+++ b/src/forces.F90
@@ -248,7 +248,7 @@ subroutine force_quantum(fx, fy, fz, x, y, z, amg, energy)
 !   end if
    ! Tuckerman normal modes Hamiltonian
    if (inormalmodes == 2) then
-      ak = NWALK * TEMP**2 * amg / sqrt(nwalk * 1.0D0)
+      ak = NWALK * TEMP**2 * amg / dsqrt(nwalk * 1.0D0)
    end if
 
    equant = 0.0D0

--- a/src/gle.F90
+++ b/src/gle.F90
@@ -100,9 +100,9 @@ contains
       ! TODO: implement global version according to equations 51-54
       do iw = 1, nwalk
          do iat = 1, natom
-            px(iat, iw) = c1(iw) * px(iat, iw) + c2(iw) * ran(pom) * sqrt(m(iat, iw))
-            py(iat, iw) = c1(iw) * py(iat, iw) + c2(iw) * ran(pom + 1) * sqrt(m(iat, iw))
-            pz(iat, iw) = c1(iw) * pz(iat, iw) + c2(iw) * ran(pom + 2) * sqrt(m(iat, iw))
+            px(iat, iw) = c1(iw) * px(iat, iw) + c2(iw) * ran(pom) * dsqrt(m(iat, iw))
+            py(iat, iw) = c1(iw) * py(iat, iw) + c2(iw) * ran(pom + 1) * dsqrt(m(iat, iw))
+            pz(iat, iw) = c1(iw) * pz(iat, iw) + c2(iw) * ran(pom + 2) * dsqrt(m(iat, iw))
             pom = pom + 3
          end do
       end do
@@ -441,7 +441,7 @@ contains
       do i = 1, ns + 1
          call gautrg(ran, natom * 3)
          do j = 1, natom
-            sqm = sqrt(mass(j, iw))
+            sqm = dsqrt(mass(j, iw))
             !<-- if m!= 1, alternatively one could perform the scaling here (check also init!)
             p(j, i) = ran(j) * sqm
             p(j + natom, i) = ran(j + natom) * sqm
@@ -529,7 +529,7 @@ contains
       end do
       do i = 1, n
          if (D(i, i) >= 0.0D0) then
-            D(i, i) = sqrt(D(i, i))
+            D(i, i) = dsqrt(D(i, i))
          else
             write (0, *) "Warning: negative eigenvalue (", D(i, i), ")in LDL^T decomposition."
             D(i, i) = 0.0D0

--- a/src/init.F90
+++ b/src/init.F90
@@ -1131,8 +1131,6 @@ contains
       print '(a)', '  /_/        \_\ |_____/   |_|  |_|    \_|'
       print '(a)', ' '
 
-! TODO: Pass version as compiler parameter
-      print '(a)', ' version 1.1'
       print '(a)', ' D. Hollas, J. Suchan, O. Svoboda, M. Oncak, P. Slavicek'
       print '(a)', ' '
    end subroutine print_logo

--- a/src/landau_zener.F90
+++ b/src/landau_zener.F90
@@ -135,7 +135,7 @@ contains
          ! Three point minima of adiabatic splitting Zjk
          if ((en_diff(1) > en_diff(2)) .and. (en_diff(2) < en_diff(3)) .and. (it > 2)) then
             second_der = ((en_diff(3) - 2 * en_diff(2) + en_diff(1)) / dt**2)
-            prob(ist1) = exp(-PI / 2 * (sqrt(en_diff(2)**3 / second_der)))
+            prob(ist1) = exp(-PI / 2 * (dsqrt(en_diff(2)**3 / second_der)))
             write (fmt_in, '(I2.2)') ist
             write (fmt_out, '(I2.2)') ist1
             write (*, *) "Three-point minimum (", trim(fmt_in), "->", trim(fmt_out), &
@@ -216,7 +216,7 @@ contains
             call force_clas(fxc, fyc, fzc, x, y, z, eclas, pot)
 
             !d) Simple velocity rescaling (https://doi.org/10.1063/1.4882073)
-            vel_rescale = sqrt(1 - (dE / Ekin))
+            vel_rescale = dsqrt(1 - (dE / Ekin))
             do iat = 1, natom
                vx(iat, 1) = vx(iat, 1) * vel_rescale
                vy(iat, 1) = vy(iat, 1) * vel_rescale
@@ -249,7 +249,7 @@ contains
          prob = 0.0D0
 
          Ekin = ekin_v(vx, vy, vz)
-         molveloc = sqrt(2.0D0 * Ekin / sum(am(1:natom)))
+         molveloc = dsqrt(2.0D0 * Ekin / sum(am(1:natom)))
          call vranf(ran, 1)
          hop_rdnum = ran(1)
          icross = 0
@@ -335,7 +335,7 @@ contains
             end do
 
             !Simple velocity scaling
-            !vel_rescale = sqrt(1-(Epot/Ekin))
+            !vel_rescale = dsqrt(1-(Epot/Ekin))
             !do iat=1, natom
             !    vx(iat,1) = vx(iat,1) * vel_rescale
             !    vy(iat,1) = vy(iat,1) * vel_rescale

--- a/src/nosehoover.F90
+++ b/src/nosehoover.F90
@@ -125,7 +125,6 @@ contains
       ! 1/(beta*omega_p^2)
       ! where
       ! omega_p=sqrt(P)/(beta*hbar)
-      ! DH DEBUG
       if (ipimd == 1 .and. inormalmodes /= 1) then
 
          do iw = 1, nwalk
@@ -162,9 +161,9 @@ contains
                call gautrg(ran, natom * 3)
                ipom = 1
                do iat = 1, natom
-                  pnhx(iat, iw, inh) = ran(ipom) * sqrt(temp * Qm(iw))
-                  pnhy(iat, iw, inh) = ran(ipom + 1) * sqrt(temp * Qm(iw))
-                  pnhz(iat, iw, inh) = ran(ipom + 2) * sqrt(temp * Qm(iw))
+                  pnhx(iat, iw, inh) = ran(ipom) * dsqrt(temp * Qm(iw))
+                  pnhy(iat, iw, inh) = ran(ipom + 1) * dsqrt(temp * Qm(iw))
+                  pnhz(iat, iw, inh) = ran(ipom + 2) * dsqrt(temp * Qm(iw))
                end do
                ipom = ipom + 3
             end do
@@ -177,7 +176,7 @@ contains
                ! +1 if nmolt=1, gautrg needs array at least of length=2
                call gautrg(ran, nmolt + 1)
                do imol = 1, nmolt
-                  pnhx(imol, iw, inh) = ran(imol) * sqrt(temp * ms(imol, inh))
+                  pnhx(imol, iw, inh) = ran(imol) * dsqrt(temp * ms(imol, inh))
                end do
             end do
          end do

--- a/src/potentials.F90
+++ b/src/potentials.F90
@@ -87,7 +87,7 @@ contains
          dy = y(2, i) - y(1, i)
          dz = z(2, i) - z(1, i)
          r = dx**2 + dy**2 + dz**2
-         r = sqrt(r)
+         r = dsqrt(r)
          fac = k * (r - r0) / r
          fxab(1, i) = fac * dx
          fxab(2, i) = -fxab(1, i)
@@ -112,7 +112,7 @@ contains
          dy = y(2, i) - y(1, i)
          dz = z(2, i) - z(1, i)
          r = dx**2 + dy**2 + dz**2
-         r = sqrt(r)
+         r = dsqrt(r)
          fac = k * (r - r0) / r
          hess(1, 1, i) = (k * dx**2 / r**2 - fac * dx**2 / r**2 + fac) / nwalk
          hess(2, 2, i) = (k * dy**2 / r**2 - fac * dy**2 / r**2 + fac) / nwalk
@@ -159,7 +159,7 @@ contains
 !NOT REALLY SURE about a
 !if it is not set from input, we determine it from k(normaly used for
 !harmon osciallator)
-      if (a <= 0) a = sqrt(k / 2 / De)
+      if (a <= 0) a = dsqrt(k / 2 / De)
 
       eclas = 0.0D0
 
@@ -168,7 +168,7 @@ contains
          dy = y(2, i) - y(1, i)
          dz = z(2, i) - z(1, i)
          r = dx**2 + dy**2 + dz**2
-         r = sqrt(r)
+         r = dsqrt(r)
          ex = exp(-a * (r - r0))
          fac = 2 * a * ex * De * (1 - ex) / r
          fxab(1, i) = fac * dx
@@ -189,7 +189,7 @@ contains
       integer :: i, ipom1, ipom2
 
 !NOT REALLY SURE about a
-      a = sqrt(k / 2 / De)
+      a = dsqrt(k / 2 / De)
 
       do i = 1, nwalk
 
@@ -197,7 +197,7 @@ contains
          dy = y(2, i) - y(1, i)
          dz = z(2, i) - z(1, i)
          r = dx**2 + dy**2 + dz**2
-         r = sqrt(r)
+         r = dsqrt(r)
          ex = exp(-a * (r - r0))
          fac = 2 * a * ex * De * (1 - ex) / r
          fac2 = 2 * De * a**2 * ex**2 / r**2

--- a/src/remd.F90
+++ b/src/remd.F90
@@ -149,7 +149,7 @@ contains
       allocate (fzc_new(size1, size2))
 
       ! Momenta are scaled according to the new temperature
-      ! p_new = p_old * sqrt(T_new/T_old)
+      ! p_new = p_old * dsqrt(T_new/T_old)
       if (my_rank == rank1) then
          scal = dsqrt(temp_list(my_rank + 1) / temp_list(my_rank + 2))
       else if (my_rank == rank2) then

--- a/src/sh_integ.F90
+++ b/src/sh_integ.F90
@@ -402,7 +402,7 @@ contains
          call abinerror('surfacehop')
       end if
 
-      renormalization_factor = sqrt(renormalization_factor)
+      renormalization_factor = dsqrt(renormalization_factor)
 
       cel_re(current_state, itrj) = cel_re(current_state, itrj) * renormalization_factor
       cel_im(current_state, itrj) = cel_im(current_state, itrj) * renormalization_factor

--- a/src/surfacehop.F90
+++ b/src/surfacehop.F90
@@ -875,11 +875,11 @@ contains
       ! Rescaling the velocities
 
       if (b_temp < 0) then
-         g_temp = (b_temp + sqrt(c_temp)) / 2.0D0 / a_temp
+         g_temp = (b_temp + dsqrt(c_temp)) / 2.0D0 / a_temp
       end if
 
       if (b_temp >= 0) then
-         g_temp = (b_temp - sqrt(c_temp)) / 2.0D0 / a_temp
+         g_temp = (b_temp - dsqrt(c_temp)) / 2.0D0 / a_temp
       end if
 
       do iat = 1, natom
@@ -962,7 +962,7 @@ contains
 
       if (ekin >= de) then
 
-         alfa = sqrt(1 - de / ekin)
+         alfa = dsqrt(1 - de / ekin)
 
          do iat = 1, natom
             vx(iat, itrj) = alfa * vx(iat, itrj)

--- a/src/transform.F90
+++ b/src/transform.F90
@@ -456,7 +456,7 @@ contains
 
       omega_n = NWALK * TEMP
       if (inormalmodes == 2) then
-         omega_n = omega_n * sqrt(NWALK * 1.D0)
+         omega_n = omega_n * dsqrt(NWALK * 1.D0)
       end if
       equantx = 0.0D0
       equanty = 0.0D0

--- a/src/utils.F90
+++ b/src/utils.F90
@@ -7,13 +7,13 @@ module mod_utils
    public
 contains
 
-   real(DP) function get_distance(x, y, z, at1, at2, iw)
+   real(DP) function get_distance(x, y, z, at1, at2, iw) result(r)
       real(DP), intent(in) :: x(:, :), y(:, :), z(:, :)
       integer, intent(in) :: at1, at2, iw
       character(len=*), parameter :: error_msg = 'Atom indices in get_distance() must be unique'
-      real(DP) :: r
 
       if (at1 == at2) then
+         r = 0
          call fatal_error(__FILE__, __LINE__, error_msg)
          return
       end if
@@ -21,11 +21,10 @@ contains
       r = (x(at1, iw) - x(at2, iw))**2
       r = r + (y(at1, iw) - y(at2, iw))**2
       r = r + (z(at1, iw) - z(at2, iw))**2
-      r = sqrt(r)
-      get_distance = r
+      r = dsqrt(r)
    end function get_distance
 
-   real(DP) function get_angle(x, y, z, at1, at2, at3, iw)
+   real(DP) function get_angle(x, y, z, at1, at2, at3, iw) result(angle)
       use mod_const, only: PI
       real(DP), intent(in) :: x(:, :), y(:, :), z(:, :)
       integer, intent(in) :: iw
@@ -35,6 +34,7 @@ contains
       character(len=*), parameter :: error_msg = 'Atom indices in get_angle() must be unique'
 
       if (at1 == at2 .or. at1 == at3 .or. at2 == at3) then
+         angle = 0
          call fatal_error(__FILE__, __LINE__, error_msg)
          return
       end if
@@ -45,10 +45,8 @@ contains
       vec2x = x(at3, iw) - x(at2, iw)
       vec2y = y(at3, iw) - y(at2, iw)
       vec2z = z(at3, iw) - z(at2, iw)
-      get_angle = 180 / pi * acos((vec1x * vec2x + vec1y * vec2y + vec1z * vec2z) / &
-               & (sqrt(vec1x**2 + vec1y**2 + vec1z**2) * sqrt(vec2x**2 + vec2y**2 + vec2z**2)))
-
-      return
+      angle = 180 / pi * acos((vec1x * vec2x + vec1y * vec2y + vec1z * vec2z) / &
+               & (dsqrt(vec1x**2 + vec1y**2 + vec1z**2) * dsqrt(vec2x**2 + vec2y**2 + vec2z**2)))
    end function get_angle
 
    real(DP) function get_dihedral(x, y, z, at1, at2, at3, at4, iw, shiftdih)
@@ -84,7 +82,7 @@ contains
       ! TODO: Add error handling for malformed dihedral angles to prevent division by zero
       get_dihedral = 180 / pi * acos( &
              & (norm1x * norm2x + norm1y * norm2y + norm1z * norm2z) / &
-             & (sqrt(norm1x**2 + norm1y**2 + norm1z**2) * sqrt(norm2x**2 + norm2y**2 + norm2z**2)) &
+             & (dsqrt(norm1x**2 + norm1y**2 + norm1z**2) * dsqrt(norm2x**2 + norm2y**2 + norm2z**2)) &
              & )
 
       if (sign > 0) get_dihedral = shiftdih - get_dihedral

--- a/src/vinit.F90
+++ b/src/vinit.F90
@@ -47,7 +47,7 @@ contains
          pom = 1
          do iat = 1, natom
             ! Variance of distribution
-            sigma = sqrt(TEMP / MASS(iat))
+            sigma = dsqrt(TEMP / MASS(iat))
 
             ! Velocity vector of iat-th atom
             vx(iat, iw) = sigma * rans(pom)
@@ -98,11 +98,11 @@ contains
 
       if (my_rank == 0) write (*, *) 'Initial temperature (K):', temp_mom * autok
 
-      ! TODO: pro normal modes nemusi nutne fungovat!
+      ! TODO: Might not work correctly for PIMD with normal modes!
       if (scaleveloc == 1 .and. temp_mom > 0.1E-10) then
 
          if (my_rank == 0) write (*, *) 'Scaling velocities to correct temperature.'
-         scal = sqrt(temp / temp_mom)
+         scal = dsqrt(temp / temp_mom)
          vx = vx * scal
          vy = vy * scal
          vz = vz * scal

--- a/tests/CMDLINE/test.sh
+++ b/tests/CMDLINE/test.sh
@@ -14,3 +14,8 @@ $ABINEXE -invalid > abin.out || true
 
 # Test that ABIN prints help, without an error
 $ABINEXE -h >> abin.out || echo "ERROR when printing help" >> ERROR
+$ABINEXE --help >> abin.out || echo "ERROR when printing help" >> ERROR
+
+# Test that ABIN prints version, without an error
+$ABINEXE -V >> abin.out || echo "ERROR when printing version" >> ERROR
+$ABINEXE --version >> abin.out || echo "ERROR when printing version" >> ERROR

--- a/utils/analyze_movie.f90
+++ b/utils/analyze_movie.f90
@@ -67,7 +67,7 @@ real*8 function get_angle(at1, at2, at3, boxx, boxy, boxz)
    end if
 
    get_angle=180/pi*acos((vec1x*vec2x+vec1y*vec2y+vec1z*vec2z)/ &
-   (dsqrt(vec1x**2+vec1y**2+vec1z**2)*sqrt(vec2x**2+vec2y**2+vec2z**2)))
+   (dsqrt(vec1x**2+vec1y**2+vec1z**2)*dsqrt(vec2x**2+vec2y**2+vec2z**2)))
 
 return 
 end function get_angle
@@ -113,7 +113,7 @@ real*8 function get_dihedral(at1, at2, at3, at4, shiftdih, boxx, boxy, boxz)
    
    sign = norm1x*vec3x+norm1y*vec3y+norm1z*vec3z
    get_dihedral = 180/pi*acos((norm1x*norm2x+norm1y*norm2y+norm1z*norm2z)/ &
-   (sqrt(norm1x**2+norm1y**2+norm1z**2)*sqrt(norm2x**2+norm2y**2+norm2z**2)))
+   (dsqrt(norm1x**2+norm1y**2+norm1z**2)*dsqrt(norm2x**2+norm2y**2+norm2z**2)))
    
    if (sign.gt.0) get_dihedral = shiftdih - get_dihedral
    


### PR DESCRIPTION
Plus some minor stuff:
 - take date/time from preprocessor
 - print compiler version and options for all compilers.
This works with Intel >=2018 and Gfortran >= 4.6  Since Intel 2017 currently cannot compile ABIN with MPI, I think it is fine to say we partly suppport Intel 2018 and up.

 - change `sqrt` to `dsqrt`.
Apparently, in new compilers this probably/hopefully does not matter, as `sqrt` seems to adapt to its input precision.
Tested with the following program, compiled with gfortran 7.3.0, 4.8, 5.6 and ifort 18.0.2.

```fortran
program test_sqrt
   real(8) :: r = 4.0D0

   print *, r, sqrt(r), dsqrt(r)
   print *, sqrt(4.0), sqrt(4.0D0), dsqrt(4.0D0)
end program
```

Output:
```
   4.0000000000000000        2.0000000000000000    2.0000000000000000
   2.00000000       2.0000000000000000        2.0000000000000000
```