### PR TITLE
Ensure implicit none via compiler option

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -15,7 +15,8 @@ env:
   CODECOV_OPTIONS: -Z -X coveragepy -X xcode
 
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp -Wall --coverage -ffpe-trap=invalid,zero,overflow,denormal
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 
 jobs:
 
@@ -83,7 +84,6 @@ jobs:
          gcc_v: [7, 9, 10]
     env:
       FC: gfortran
-      FFLAGS: -O3 -fopenmp -Wall
       GCC_V: ${{ matrix.gcc_v}}
 
     steps:
@@ -108,6 +108,8 @@ jobs:
 
     - name: build ABIN
       run: ./configure --pfunit ${HOME}/pfunit/build/installed/ && make
+      env:
+        FFLAGS: ${{ env.OPTIMIZED_FFLAGS }}
 
     - name: Run Unit tests
       run: make unittest

--- a/configure
+++ b/configure
@@ -43,12 +43,14 @@ OPTIONS
 "
 }
 
+warning_flags="-Wall -Wno-integer-division -Wno-maybe-uninitialized"
+
 # Overwrite default options from command line
 PARAMS="$@"
 while [[ $# -gt 0 ]]; do
     case "$1" in
       --debug)
-        FFLAGS="-g -O0 -fopenmp -Wall"
+        FFLAGS="-g -O0 -fopenmp -fimplicit-none $warning_flags"
         shift
         ;;
       --mpi)
@@ -109,7 +111,7 @@ done
 
 # Set to default if FFLAGS is not defined yet, see
 # https://stackoverflow.com/questions/11362250/in-bash-how-do-i-test-if-a-variable-is-defined-in-u-mode
-: ${FFLAGS:='-O2 -fopenmp -Wall'}
+: ${FFLAGS:="-O2 -fopenmp -fimplicit-none $warning_flags"}
 
 if [[ -z ${FC-} ]];then
    if [[ $MPI = "TRUE" ]];then

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-F_OBJS := modules.o fortran_interfaces.o error.o utils.o io.o random.o arrays.o qmmm.o fftw_interface.o \
+F_OBJS := constants.o fortran_interfaces.o error.o modules.o files.o utils.o io.o random.o arrays.o qmmm.o fftw_interface.o \
           shake.o nosehoover.o gle.o transform.o potentials.o estimators.o ekin.o vinit.o plumed.o \
           remd.o force_bound.o water.o force_cp2k.o sh_integ.o surfacehop.o landau_zener.o\
           force_mm.o tera_mpi_api.o force_tera.o force_terash.o force_abin.o en_restraint.o analyze_ext_template.o geom_analysis.o analysis.o \

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -1,0 +1,38 @@
+! Exact values for ANG,AUTOKCAL and AUTODEBYE,me,AUTOM,AUTOFS,AMU:
+! Mohr, Taylor, Newell, Rev. Mod. Phys. 80 (2008) 633-730
+! and using the thermochemical calorie (1 cal = 4.184 J):'
+
+! TODO: Update physical constant according to the latest data
+! https://physics.nist.gov/cuu/Constants/bibliography.html
+
+! ABIN uses atomic units internally
+module mod_const
+   implicit none
+   ! TODO; Separate DP to its own module, mod_kinds
+   ! and rename mod_const to mod_phys_const
+   integer, parameter :: DP = kind(1.0D0)
+   ! Exact values of Planck and Avogadro constants according
+   ! to the SI redefinition of kilogram in 2019.
+   ! TODO: Define all other constants based on base SI units.
+   real(DP), parameter :: AVOGADRO = 6.02214076D23
+   real(DP), parameter :: PLANCK = 6.626070150D-23
+   ! Hartree to Joul converstion according to
+   ! https://physics.nist.gov/cuu/Constants/Table/allascii.txt
+   real(DP), parameter :: AUTOJ = 4.3597447222071D-18 ! hartree -> J
+   real(DP), parameter :: AMU = 1822.888484264545D0 ! atomic mass unit
+   real(DP), parameter :: ANG = 1.889726132873D0 ! Angstroms -> Bohrs
+   real(DP), parameter :: AUTOFS = 0.02418884326505D0 !atomic units to femtosecs
+   real(DP), parameter :: PI = 3.14159265358979323846D0
+   real(DP), parameter :: AUTOK = 3.1577464D5 ! temperature in a.u. to Kelvins
+   real(DP), parameter :: ME = 9.10938215D-31 ! electron mass
+   real(DP), parameter :: AUTOM = 5.2917720859D-11 ! atomic length
+   real(DP), parameter :: AUTOCM = 2.1947463D5 ! atomic units to cm-1
+   real(DP), parameter :: AUTOKCAL = 6.2750946943D2 ! Ha -> kcal/mol
+   real(DP), parameter :: CALTOJ = 4.184D0
+   real(DP), parameter :: AUTOKK = 3.1577322D5
+   real(DP), parameter :: AUTOEV = 27.21138386D0
+   real(DP), parameter :: AUTODEBYE = 2.54174623D0
+   ! Boltzmann constant in a.u., assumed to be 1.0d0 in the program
+   real(DP), parameter :: KBinAU = 0.9999999748284666D0
+   save
+end module mod_const

--- a/src/error.F90
+++ b/src/error.F90
@@ -57,6 +57,7 @@ contains
    end subroutine fatal_error
 
    subroutine print_error_and_stop(filename, line, message)
+      use mod_interfaces, only: finish
       character(*), intent(in) :: filename
       integer, intent(in) :: line
       character(*), intent(in) :: message

--- a/src/files.F90
+++ b/src/files.F90
@@ -1,0 +1,207 @@
+! Module for permanent file handling
+
+! Note that we're not trying to explicitly handle I/O errors here.
+! If open() or write fails, we crash ungracefully.
+module mod_files
+   implicit none
+   public
+   private :: CHFILES
+   ! Defines maximum number of units available for permanently opened files
+   integer, parameter :: MAXUNITS = 50, MAXFILENAME = 50
+   character(len=MAXFILENAME) :: CHFILES(MAXUNITS)
+
+   ! UNIT 1 is reserved for CP2K!!!
+   integer, parameter :: UMOVIE = 10, UVELOC = 2, UFORCE = 15
+   integer, parameter :: UENERGY = 3, UTEMPER = 4
+   integer, parameter :: URADIUS = 11
+   ! PIMD stuff
+   integer, parameter :: UESTENERGY = 12, UCV = 13, UCVDCV = 14
+   ! Surface hopping stuff
+   integer, parameter :: UPOP = 20, UPROB = 21, UPES = 22
+   integer, parameter :: UDOTPROD = 23, UNACME = 24, UWFCOEF = 25
+   integer, parameter :: UPHASE = 26, UBKL = 27
+   ! So far only for TeraChem
+   integer, parameter :: UDOTPRODCI = 31, UCHARGES = 32
+   integer, parameter :: UDIP = 33, UTDIP = 34
+   integer, parameter :: UWFN = 35 ! this one is not permanently opened
+   ! Analysis output
+   integer, parameter :: UDIST = 36, UANG = 37, UDIH = 38
+   save
+
+contains
+
+   subroutine files_init(isbc, phase, ndist, nang, ndih)
+      use mod_general
+      use mod_system, only: names
+      integer, intent(in) :: isbc, phase, ndist, nang, ndih
+      character(len=10) :: chaccess
+      integer :: i
+
+      do i = 1, MAXUNITS
+         chfiles(i) = ''
+      end do
+
+      chfiles(UVELOC) = 'velocities.xyz'
+      chfiles(UFORCE) = 'forces.xyz'
+      chfiles(UENERGY) = 'energies.dat'
+      chfiles(UTEMPER) = 'temper.dat'
+
+!  radius for spherical boundary conditions
+      chfiles(URADIUS) = 'radius.dat'
+
+!  Files for PIMD estimators
+      chfiles(UESTENERGY) = 'est_energy.dat'
+      chfiles(UCV) = 'cv.dat'
+!  file for advanced cv estimator
+      chfiles(UCVDCV) = 'cv_dcv.dat'
+
+!  Files for Surface Hopping
+      chfiles(UPOP) = 'pop.dat'
+      chfiles(UPROB) = 'prob.dat'
+      chfiles(UPES) = 'PES.dat'
+      chfiles(UDOTPROD) = 'dotprod.dat'
+      chfiles(UNACME) = 'nacm_all.dat'
+      chfiles(UWFCOEF) = 'wfcoef.dat'
+      chfiles(UPHASE) = 'phase.dat'
+      chfiles(UBKL) = 'bkl.dat'
+!  Files for TeraChem SH interface
+      chfiles(UCHARGES) = 'charges.dat'
+      chfiles(UDIP) = 'dipoles.dat'
+      chfiles(UTDIP) = 'trans_dipoles.dat'
+      chfiles(UDOTPRODCI) = 'dotprodci.dat'
+
+!  Geometry analysis output
+      chfiles(UDIST) = 'distances.dat'
+      chfiles(UANG) = 'angles.dat'
+      chfiles(UDIH) = 'dihedrals.dat'
+
+      ! Here we ensure, that previous files are deleted
+      if (irest == 0) then
+         chaccess = 'SEQUENTIAL'
+      else
+         chaccess = 'APPEND'
+      end if
+
+      chfiles(UMOVIE) = 'movie.xyz'
+
+      if (iremd == 1) then
+         do i = 1, MAXUNITS
+            write (chfiles(i), '(A,I2.2)') trim(chfiles(i))//'.', my_rank
+         end do
+      end if
+
+!  OPEN trajectory file
+!  Trajectory file is opened later in output function trajout
+!  to prevent creating empty movie.xyz and then failing
+!  We still open when using CP2K interface, since otherwise
+!  strangely more MPI ranks can write to this file if not opened here...
+!   if(pot.eq.'_cp2k_')then
+!      open(UMOVIE,file=chfiles(UMOVIE),access=chaccess,action='write')
+!   end if
+
+      if (nwritev > 0) then
+!      if(iremd.eq.1)then
+!         write(chout,'(A,I2.2)')'vel.dat.',my_rank
+!      else
+!         chout='vel.dat'
+!      end if
+         open (UVELOC, file=chfiles(UVELOC), access=chaccess, action='write')
+      end if
+
+      if (nwritef > 0) open (UFORCE, file=chfiles(UFORCE), access=chaccess, action='write')
+
+      if (ipimd /= 1) then
+         open (UENERGY, file=chfiles(UENERGY), access=chaccess, action='write')
+         write (UENERGY, *) '#        Time[fs] E-potential           E-kinetic     E-Total    E-Total-Avg'
+      end if
+
+      if (ipimd == 1) then
+         open (UESTENERGY, file=chfiles(UESTENERGY), access=chaccess, action='write')
+         write (UESTENERGY, *) '#     Time[fs] E-potential  E-primitive   E-virial  CumulAvg_prim  CumulAvg_vir'
+      end if
+
+      open (UTEMPER, file=chfiles(UTEMPER), access=chaccess, action='write')
+      write (UTEMPER, *) '#      Time[fs] Temperature T-Average Conserved_quantity_of_thermostat'
+
+      if (ipimd == 5) then
+         open (UPES, file=chfiles(UPES), access=chaccess, action='write')
+         write (UPES, *) '#    Time[fs] Potential energies (singlets, triplets)'
+         open (UPOP, file=chfiles(UPOP), access=chaccess, action='write')
+         write (UPOP, *) '#    Time[fs] CurrentState   Populations Sum-of-Populations'
+      end if
+
+      if (ipimd == 2) then
+         open (UPOP, file=chfiles(UPOP), access=chaccess, action='write')
+         write (UPOP, *) '#    Time[fs] CurrentState   Populations Sum-of-Populations'
+         open (UPROB, file=chfiles(UPROB), access=chaccess, action='write')
+         write (UPROB, *) '#    Time[fs] CurrentState   Probabilities'
+         open (UPES, file=chfiles(UPES), access=chaccess, action='write')
+         write (UPES, *) '#    Time[fs] Potential energies'
+         open (UNACME, file=chfiles(UNACME), access=chaccess, action='write')
+         open (UDOTPROD, file=chfiles(UDOTPROD), access=chaccess, action='write')
+         write (UDOTPROD, *) '#    Time[fs] dotproduct(i,j) [i=1,nstate-1;j=i+1,nstate]'
+         if (idebug > 1) then
+            open (UBKL, file=chfiles(UBKL), access=chaccess, action='write')
+            write (UBKL, *) '# Hopping probabilities - bkl(i) [i=1,nstate]'
+            open (UWFCOEF, file=chfiles(UWFCOEF), access=chaccess, action='write', recl=250)
+            write (UWFCOEF, *) '# WF coefficients c_real(i),i=1,nstate c_imag(i),i=1,nstate'
+            if (phase == 1) then
+               open (UPHASE, file=chfiles(UPHASE), access=chaccess, action='write')
+               write (UPHASE, *) '# Lower triangular matrix of gamma (phase)  gamma(i,j) [i=1,nstate ;j=1,i-1]'
+            end if
+         end if
+
+         if (pot == '_tera_') then
+            open (UCHARGES, file=chfiles(UCHARGES), access=chaccess, action='write')
+            write (UCHARGES, *) '# Atomic charges from current electronic state'
+            write (UCHARGES, *) '# Time  st ', (names(i), i=1, natom)
+            open (UDOTPRODCI, file=chfiles(UDOTPRODCI), access=chaccess, action='write')
+            write (UDOTPRODCI, *) '# Dot products between current and previous CI vectors.'
+            write (UDOTPRODCI, *) '# Time  cidotprod1  cidotprod2 ... '
+            open (UDIP, file=chfiles(UDIP), access=chaccess, action='write')
+            write (UDIP, *) '# Time  dip_tot.1 dip_tot.2 ... dip_x.1 dip_y.1 dip_z.1 dip_x.2 dip_y.2 dip_z.2.'
+            open (UTDIP, file=chfiles(UTDIP), access=chaccess, action='write')
+            write (UTDIP, *) '# Time  st  tdip_tot.1 tdip_tot.2 ... tdip_x.1 tdip_y.1 tdip_z.1 tdip_x.2 tdip_y.2 tdip_z.2.'
+         end if
+      end if
+
+      if (ipimd /= 2 .and. pot == '_tera_') then
+         open (UCHARGES, file=chfiles(UCHARGES), access=chaccess, action='write')
+         write (UCHARGES, *) '# Atomic Mulliken charges from current electronic state'
+         write (UCHARGES, *) '# Time_step Bead_index ', (names(i), i=1, natom)
+
+         open (UDIP, file=chfiles(UDIP), access=chaccess, action='write')
+         write (UDIP, *) '# Time Bead_index |D| Dx Dy Dz'
+      end if
+
+      if (isbc == 1) then
+         open (URADIUS, file=chfiles(URADIUS), access=chaccess, action='write')
+         write (URADIUS, *) '#TimeStep     Radius[ANG]   approximate density[kg.m^3]'
+      end if
+
+      if (icv == 1) then
+         open (UCV, file=chfiles(UCV), access=chaccess, action='write')
+         write (UCV, *) '#         Time[fs]  Cv-prim   Cv-vir  Cv_cumul_prim  Cv_cumul_vir'
+         if (ihess == 1) then
+            open (UCVDCV, file=chfiles(UCVDCV), access=chaccess, action='write')
+            write (UCVDCV, *) '#         Time[fs]  Cv-DCV   Cv_cumul_DCV'
+         end if
+      end if
+
+      ! Analysis
+      if (ndist > 0) then
+         open (UDIST, file=chfiles(UDIST), access=chaccess, action='write')
+         write (UDIST, '(A)') "# Distances [Angstrom]"
+      end if
+      if (nang > 0) then
+         open (UANG, file=chfiles(UANG), access=chaccess, action='write')
+         write (UANG, '(A)') "# Angles [Degree]"
+      end if
+      if (ndih > 0) then
+         open (UDIH, file=chfiles(UDIH), access=chaccess, action='write')
+         write (UDIH, '(A)') "# Dihedral Angles [Degree]"
+      end if
+
+   end subroutine files_init
+
+end module mod_files

--- a/src/fortran_interfaces.F90
+++ b/src/fortran_interfaces.F90
@@ -69,7 +69,23 @@ module mod_interfaces
          integer, intent(in) :: iw
       end subroutine oniom
 
+      subroutine omp_set_num_threads(nthreads)
+         integer, intent(in) :: nthreads
+      end subroutine omp_set_num_threads
+
+      subroutine print_runtime_info()
+      end subroutine
+
+      ! TODO: This interface currently doesn't work, probably because
+      ! of how we pass the 2D arrays...
+      !subroutine force_water(x, y, z, fx, fy, fz, eclas, natom, walkmax, watpot) !bind(C)
+      !   use, intrinsic :: iso_c_binding
+      !   real(C_DOUBLE), intent(in) :: x(:, :), y(:, :), z(:, :)
+      !   real(C_DOUBLE), intent(inout) :: fx(:, :), fy(:, :), fz(:, :)
+      !   real(C_DOUBLE), intent(inout) :: eclas
+      !   integer(C_INT), intent(in) :: natom, walkmax, watpot
+      !end subroutine
+
    end interface
 
 end module mod_interfaces
-

--- a/src/modules.F90
+++ b/src/modules.F90
@@ -4,51 +4,13 @@
 ! for passing global variables to different subroutines.
 !------------------------------------------------------------------------------------
 
-! Exact values for ANG,AUTOKCAL and AUTODEBYE,me,AUTOM,AUTOFS,AMU:
-! Mohr, Taylor, Newell, Rev. Mod. Phys. 80 (2008) 633-730
-! and using the thermochemical calorie (1 cal = 4.184 J):'
-
-! TODO: Update physical constant according to the latest data
-! https://physics.nist.gov/cuu/Constants/bibliography.html
-
-! ABIN uses atomic units internally
-module mod_const
-   implicit none
-   ! TODO; Separate DP to its own module, mod_kinds
-   ! and rename mod_const to mod_phys_const
-   integer, parameter :: DP = kind(1.0D0)
-   ! Exact values of Planck and Avogadro constants according
-   ! to the SI redefinition of kilogram in 2019.
-   ! TODO: Define all other constants based on base SI units.
-   real(DP), parameter :: AVOGADRO = 6.02214076D23
-   real(DP), parameter :: PLANCK = 6.626070150D-23
-   ! Hartree to Joul converstion according to
-   ! https://physics.nist.gov/cuu/Constants/Table/allascii.txt
-   real(DP), parameter :: AUTOJ = 4.3597447222071D-18 ! hartree -> J
-   real(DP), parameter :: AMU = 1822.888484264545D0 ! atomic mass unit
-   real(DP), parameter :: ANG = 1.889726132873D0 ! Angstroms -> Bohrs
-   real(DP), parameter :: AUTOFS = 0.02418884326505D0 !atomic units to femtosecs
-   real(DP), parameter :: PI = 3.14159265358979323846D0
-   real(DP), parameter :: AUTOK = 3.1577464D5 ! temperature in a.u. to Kelvins
-   real(DP), parameter :: ME = 9.10938215D-31 ! electron mass
-   real(DP), parameter :: AUTOM = 5.2917720859D-11 ! atomic length
-   real(DP), parameter :: AUTOCM = 2.1947463D5 ! atomic units to cm-1
-   real(DP), parameter :: AUTOKCAL = 6.2750946943D2 ! Ha -> kcal/mol
-   real(DP), parameter :: CALTOJ = 4.184D0
-   real(DP), parameter :: AUTOKK = 3.1577322D5
-   real(DP), parameter :: AUTOEV = 27.21138386D0
-   real(DP), parameter :: AUTODEBYE = 2.54174623D0
-   ! Boltzmann constant in a.u., assumed to be 1.0d0 in the program
-   real(DP), parameter :: KBinAU = 0.9999999748284666D0
-   save
-end module mod_const
-
 ! mod_array_size contains various array limits.
 ! Modify here if you need larger arrays.
 ! Most of the other arrays are allocated dynamically.
 module mod_array_size
    use mod_const, only: DP
    implicit none
+   public
    integer, parameter :: MAXCHAIN = 10, MAXTYPES = 10
    integer, parameter :: NBINMAX = 2000, NDISTMAX = 30
    integer, parameter :: NSTMAX = 50, NTRAJMAX = 1
@@ -59,6 +21,7 @@ end module mod_array_size
 module mod_general
    use mod_const, only: DP
    implicit none
+   public
    ! Current time step
    integer :: it = 0
    ! Denotes integrator for equations of motion, see init.F90
@@ -120,29 +83,7 @@ module mod_system
    ! cannot use this
 !   use mod_utils, only: abinerror
    implicit none
-   ! TODO: move more stuff into Properties derived type
-   ! https://kiwi.atmos.colostate.edu/fortran/docs/fortran2012.key-8.pdf
-   ! TODO: We should probably move this outside of the modules.f90
-
-   ! Extra electronic properties (not mandatory)
-   type Bead_Extra_Properties
-      ! PRIVATE ! probably cannot encapsulate due to MPI TC interface
-      real(DP), allocatable :: QMcharges(:)
-      real(DP), allocatable :: MMcharges(:)
-      real(DP), allocatable :: dipole_moment(:, :) ! second argument should be 4
-      real(DP), allocatable :: transdipole_moment(:, :) ! second argument should be 4
-      real(DP), allocatable :: user_defined(:) ! let user track anything here
-      ! need to specify dimension in
-      ! input.in. Output file should
-      ! be called magic_property.dat
-   end type Bead_Extra_Properties
-
-   type Traj_Properties
-      ! Allocate based on number of nwalk
-      type(Bead_Extra_Properties), allocatable :: bead_prop(:)
-   end type Traj_Properties
-   type(Traj_Properties) :: traj_prop, traj_prop_prev
-
+   public
    real(DP), allocatable :: am(:)
    character(len=2), allocatable :: names(:)
    integer, allocatable :: inames(:)
@@ -155,42 +96,18 @@ module mod_system
    save
 contains
 
-   ! We should loop over this function over different beads
-   !subroutine read_properties(traj_prop)
-   ! use mod_general, only: nwalk, natom
-   !type(Traj_Properties), intent(inout) :: traj_prop(:)
-   !integer :: iw
-
-   ! we should make some generalized reading function in utils
-   ! i.e. dipole moments and transition dipolo moments can reuse
-   ! (e.g. simply read..) but where should we open the unit?
-   ! but maybe not, these things might be rather different?
-
-   !do iw = 1, nwalk
-
-   !end do
-
-   !end subroutine read_properties
-
-   !subroutine write_properties(traj_prop)
-   !type(Traj_Properties), intent(inout) :: traj_prop
-
-   ! should introduce nwriteprop
-   ! by default should equal nwritex
-   !end subroutine write_properties
-
-   subroutine clean_prop_tempfiles
-
-      call system("rm -f temp_dip.*.dat temp_tdip.*.dat")
-
-   end subroutine clean_prop_tempfiles
-
-   subroutine mass_init(masses, massnames)
+   ! Subroutine mass_init() populates the global am() array,
+   ! based on the atom names from names() array.
+   ! User can also specify non-standard isotopes/elements
+   subroutine mass_init(masses, massnames, natom)
       use mod_const, only: AMU
-      use mod_general, only: natom, my_rank
-      real(DP) :: masses(:)
-      character(len=2) :: massnames(:)
-      integer :: i
+      use mod_general, only: my_rank
+      use mod_error, only: fatal_error
+      real(DP), intent(in) :: masses(:)
+      character(len=2), intent(in) :: massnames(:)
+      integer, intent(in) :: natom
+      character(len=100) :: error_msg
+      integer :: i, j
       ! Accurate values for H1 and H2 taken from:
       ! Mohr, Taylor, Newell, Rev. Mod. Phys. 80 (2008) 633-730
       ! Other atomic weights taken from Handbook of Chemistry and Physics, 2013
@@ -372,24 +289,58 @@ contains
          case ('Zr')
             am(i) = 91.224D0
          case DEFAULT
-            print*,'Atom name ', names(i), ' was not found in the library.'
-            print*,'I hope you specified the mass in namelist "system"'
+            if (my_rank == 0) then
+               print*,'Atom name ', names(i), ' was not found in the library.'
+               print*,'Using user-defined mass from input file'
+            end if
          end select
       end do
 
-      call init_usermass()
+      ! Check for duplicate user defined atom names
+      do i = 1, size(massnames)
+         do j = i + 1, size(massnames)
+            if (massnames(i) == massnames(j) .and. trim(massnames(i)) /= '') then
+               error_msg = 'Duplicate atom names in input array "massnames"'
+               call fatal_error(__FILE__, __LINE__, error_msg)
+               return
+            end if
+         end do
+      end do
 
+      ! Here we overwrite library values if user provided alternative value
+      ! in the input file, or we define new atom names that are not in the library.
+      do i = 1, natom
+         do j = 1, size(massnames)
+            if (names(i) == massnames(j)) then
+
+               if (masses(j) <= 0.0D0) then
+                  error_msg = 'Mass cannot be negative. Fix arrays "masses" in the input file.'
+                  call fatal_error(__FILE__, __LINE__, error_msg)
+                  return
+               end if
+
+               if (my_rank == 0) then
+                  write (*, *) 'Defining new atom ', names(i), ' with mass=', masses(j)
+               end if
+
+               am(i) = masses(j)
+
+            end if
+         end do
+      end do
+
+      ! Catch any undefined masses
       do i = 1, natom
          if (am(i) <= 0) then
-            write (*, *) 'ERROR: Some masses were not specified. Exiting...'
-            call finish(1)
-            stop 1
+            write (error_msg, '(a,i0,a)') 'Atomic mass for atom '//names(i)//' was not specified'
+            call fatal_error(__FILE__, __LINE__, error_msg)
+            return
          end if
       end do
 
       if (natom <= 100 .and. my_rank == 0) then
          print*,''
-         print*,'-------------------ATOMIC MASSES----------------------------'
+         print*,'------------------ ATOMIC MASSES ---------------------------'
          do i = 1, natom
             write (*, '(A2, A1)', advance='no') names(i), ' '
          end do
@@ -402,257 +353,11 @@ contains
       ! Finally, convert masses to atomic units
       am = am * AMU
 
-   contains
-
-      subroutine init_usermass()
-         integer :: iat, j
-
-         do i = 1, size(massnames)
-            do j = i + 1, size(massnames)
-               if (massnames(i) == massnames(j)) then
-                  ! This is a very confusing if, I think we should just
-                  ! call abinerror unconditionally here.
-                  if ((masses(i) > 0 .or. masses(j) > 0)) then
-                     write (*, *) 'ERROR: ambiguous user input for masses.'
-                     write (*, *) 'Please, take a hard look at the input arrays "masses" and "massnames"'
-                     call finish(1)
-                     ! TODO: I think we should stop here?
-                  end if
-               end if
-            end do
-         end do
-
-         do iat = 1, natom
-            do j = 1, size(massnames)
-               if (names(iat) == massnames(j)) then
-
-                  if (masses(j) > 0) then
-                     write (*, *) 'Defining new atom ', names(iat), ' with mass=', masses(j)
-                     am(iat) = masses(j)
-                  else
-                     write (*, *) 'Mass cannot be negative. Please, fix arrays "masses" or "mass_names" in your input.'
-                  end if
-
-               end if
-            end do
-         end do
-
-      end subroutine init_usermass
-
    end subroutine mass_init
 
 end module mod_system
 
-! Module for permanent file handling
-! Note that we're not trying to explicitly handle I/O errors here.
-! If open() or write fails, we crash ungracefully.
-! TODO: Move this to a separate file.
-module mod_files
-   implicit none
-   public
-   private :: CHFILES
-   ! Defines maximum number of units available for permanently opened files
-   integer, parameter :: MAXUNITS = 50, MAXFILENAME = 50
-   character(len=MAXFILENAME) :: CHFILES(MAXUNITS)
-
-   ! UNIT 1 is reserved for CP2K!!!
-   integer, parameter :: UMOVIE = 10, UVELOC = 2, UFORCE = 15
-   integer, parameter :: UENERGY = 3, UTEMPER = 4
-   integer, parameter :: URADIUS = 11
-   ! PIMD stuff
-   integer, parameter :: UESTENERGY = 12, UCV = 13, UCVDCV = 14
-   ! Surface hopping stuff
-   integer, parameter :: UPOP = 20, UPROB = 21, UPES = 22
-   integer, parameter :: UDOTPROD = 23, UNACME = 24, UWFCOEF = 25
-   integer, parameter :: UPHASE = 26, UBKL = 27
-   ! So far only for TeraChem
-   integer, parameter :: UDOTPRODCI = 31, UCHARGES = 32
-   integer, parameter :: UDIP = 33, UTDIP = 34
-   integer, parameter :: UWFN = 35 ! this one is not permanently opened
-   ! Analysis output
-   integer, parameter :: UDIST = 36, UANG = 37, UDIH = 38
-   save
-
-contains
-
-   subroutine files_init(isbc, phase, ndist, nang, ndih)
-      use mod_general
-      use mod_system, only: names
-      integer, intent(in) :: isbc, phase, ndist, nang, ndih
-      character(len=10) :: chaccess
-      integer :: i
-
-      do i = 1, MAXUNITS
-         chfiles(i) = ''
-      end do
-
-      chfiles(UVELOC) = 'velocities.xyz'
-      chfiles(UFORCE) = 'forces.xyz'
-      chfiles(UENERGY) = 'energies.dat'
-      chfiles(UTEMPER) = 'temper.dat'
-
-!  radius for spherical boundary conditions
-      chfiles(URADIUS) = 'radius.dat'
-
-!  Files for PIMD estimators
-      chfiles(UESTENERGY) = 'est_energy.dat'
-      chfiles(UCV) = 'cv.dat'
-!  file for advanced cv estimator
-      chfiles(UCVDCV) = 'cv_dcv.dat'
-
-!  Files for Surface Hopping
-      chfiles(UPOP) = 'pop.dat'
-      chfiles(UPROB) = 'prob.dat'
-      chfiles(UPES) = 'PES.dat'
-      chfiles(UDOTPROD) = 'dotprod.dat'
-      chfiles(UNACME) = 'nacm_all.dat'
-      chfiles(UWFCOEF) = 'wfcoef.dat'
-      chfiles(UPHASE) = 'phase.dat'
-      chfiles(UBKL) = 'bkl.dat'
-!  Files for TeraChem SH interface
-      chfiles(UCHARGES) = 'charges.dat'
-      chfiles(UDIP) = 'dipoles.dat'
-      chfiles(UTDIP) = 'trans_dipoles.dat'
-      chfiles(UDOTPRODCI) = 'dotprodci.dat'
-
-!  Geometry analysis output
-      chfiles(UDIST) = 'distances.dat'
-      chfiles(UANG) = 'angles.dat'
-      chfiles(UDIH) = 'dihedrals.dat'
-
-      ! Here we ensure, that previous files are deleted
-      if (irest == 0) then
-         chaccess = 'SEQUENTIAL'
-      else
-         chaccess = 'APPEND'
-      end if
-
-      chfiles(UMOVIE) = 'movie.xyz'
-
-      if (iremd == 1) then
-         do i = 1, MAXUNITS
-            write (chfiles(i), '(A,I2.2)') trim(chfiles(i))//'.', my_rank
-         end do
-      end if
-
-!  OPEN trajectory file
-!  Trajectory file is opened later in output function trajout
-!  to prevent creating empty movie.xyz and then failing
-!  We still open when using CP2K interface, since otherwise
-!  strangely more MPI ranks can write to this file if not opened here...
-!   if(pot.eq.'_cp2k_')then
-!      open(UMOVIE,file=chfiles(UMOVIE),access=chaccess,action='write')
-!   end if
-
-      if (nwritev > 0) then
-!      if(iremd.eq.1)then
-!         write(chout,'(A,I2.2)')'vel.dat.',my_rank
-!      else
-!         chout='vel.dat'
-!      end if
-         open (UVELOC, file=chfiles(UVELOC), access=chaccess, action='write')
-      end if
-
-      if (nwritef > 0) open (UFORCE, file=chfiles(UFORCE), access=chaccess, action='write')
-
-      if (ipimd /= 1) then
-         open (UENERGY, file=chfiles(UENERGY), access=chaccess, action='write')
-         write (UENERGY, *) '#        Time[fs] E-potential           E-kinetic     E-Total    E-Total-Avg'
-      end if
-
-      if (ipimd == 1) then
-         open (UESTENERGY, file=chfiles(UESTENERGY), access=chaccess, action='write')
-         write (UESTENERGY, *) '#     Time[fs] E-potential  E-primitive   E-virial  CumulAvg_prim  CumulAvg_vir'
-      end if
-
-      open (UTEMPER, file=chfiles(UTEMPER), access=chaccess, action='write')
-      write (UTEMPER, *) '#      Time[fs] Temperature T-Average Conserved_quantity_of_thermostat'
-
-      if (ipimd == 5) then
-         open (UPES, file=chfiles(UPES), access=chaccess, action='write')
-         write (UPES, *) '#    Time[fs] Potential energies (singlets, triplets)'
-         open (UPOP, file=chfiles(UPOP), access=chaccess, action='write')
-         write (UPOP, *) '#    Time[fs] CurrentState   Populations Sum-of-Populations'
-      end if
-
-      if (ipimd == 2) then
-         open (UPOP, file=chfiles(UPOP), access=chaccess, action='write')
-         write (UPOP, *) '#    Time[fs] CurrentState   Populations Sum-of-Populations'
-         open (UPROB, file=chfiles(UPROB), access=chaccess, action='write')
-         write (UPROB, *) '#    Time[fs] CurrentState   Probabilities'
-         open (UPES, file=chfiles(UPES), access=chaccess, action='write')
-         write (UPES, *) '#    Time[fs] Potential energies'
-         open (UNACME, file=chfiles(UNACME), access=chaccess, action='write')
-         open (UDOTPROD, file=chfiles(UDOTPROD), access=chaccess, action='write')
-         write (UDOTPROD, *) '#    Time[fs] dotproduct(i,j) [i=1,nstate-1;j=i+1,nstate]'
-         if (idebug > 1) then
-            open (UBKL, file=chfiles(UBKL), access=chaccess, action='write')
-            write (UBKL, *) '# Hopping probabilities - bkl(i) [i=1,nstate]'
-            open (UWFCOEF, file=chfiles(UWFCOEF), access=chaccess, action='write', recl=250)
-            write (UWFCOEF, *) '# WF coefficients c_real(i),i=1,nstate c_imag(i),i=1,nstate'
-            if (phase == 1) then
-               open (UPHASE, file=chfiles(UPHASE), access=chaccess, action='write')
-               write (UPHASE, *) '# Lower triangular matrix of gamma (phase)  gamma(i,j) [i=1,nstate ;j=1,i-1]'
-            end if
-         end if
-
-         if (pot == '_tera_') then
-            open (UCHARGES, file=chfiles(UCHARGES), access=chaccess, action='write')
-            write (UCHARGES, *) '# Atomic charges from current electronic state'
-            write (UCHARGES, *) '# Time  st ', (names(i), i=1, natom)
-            open (UDOTPRODCI, file=chfiles(UDOTPRODCI), access=chaccess, action='write')
-            write (UDOTPRODCI, *) '# Dot products between current and previous CI vectors.'
-            write (UDOTPRODCI, *) '# Time  cidotprod1  cidotprod2 ... '
-            open (UDIP, file=chfiles(UDIP), access=chaccess, action='write')
-            write (UDIP, *) '# Time  dip_tot.1 dip_tot.2 ... dip_x.1 dip_y.1 dip_z.1 dip_x.2 dip_y.2 dip_z.2.'
-            open (UTDIP, file=chfiles(UTDIP), access=chaccess, action='write')
-            write (UTDIP, *) '# Time  st  tdip_tot.1 tdip_tot.2 ... tdip_x.1 tdip_y.1 tdip_z.1 tdip_x.2 tdip_y.2 tdip_z.2.'
-         end if
-      end if
-
-      if (ipimd /= 2 .and. pot == '_tera_') then
-         open (UCHARGES, file=chfiles(UCHARGES), access=chaccess, action='write')
-         write (UCHARGES, *) '# Atomic Mulliken charges from current electronic state'
-         write (UCHARGES, *) '# Time_step Bead_index ', (names(i), i=1, natom)
-
-         open (UDIP, file=chfiles(UDIP), access=chaccess, action='write')
-         write (UDIP, *) '# Time Bead_index |D| Dx Dy Dz'
-      end if
-
-      if (isbc == 1) then
-         open (URADIUS, file=chfiles(URADIUS), access=chaccess, action='write')
-         write (URADIUS, *) '#TimeStep     Radius[ANG]   approximate density[kg.m^3]'
-      end if
-
-      if (icv == 1) then
-         open (UCV, file=chfiles(UCV), access=chaccess, action='write')
-         write (UCV, *) '#         Time[fs]  Cv-prim   Cv-vir  Cv_cumul_prim  Cv_cumul_vir'
-         if (ihess == 1) then
-            open (UCVDCV, file=chfiles(UCVDCV), access=chaccess, action='write')
-            write (UCVDCV, *) '#         Time[fs]  Cv-DCV   Cv_cumul_DCV'
-         end if
-      end if
-
-      ! Analysis
-      if (ndist > 0) then
-         open (UDIST, file=chfiles(UDIST), access=chaccess, action='write')
-         write (UDIST, '(A)') "# Distances [Angstrom]"
-      end if
-      if (nang > 0) then
-         open (UANG, file=chfiles(UANG), access=chaccess, action='write')
-         write (UANG, '(A)') "# Angles [Degree]"
-      end if
-      if (ndih > 0) then
-         open (UDIH, file=chfiles(UDIH), access=chaccess, action='write')
-         write (UDIH, '(A)') "# Dihedral Angles [Degree]"
-      end if
-
-   end subroutine files_init
-
-end module mod_files
-
 module mod_chars
    character(len=*), parameter :: CHKNOW = 'If you know what you are doing, &
     &set iknow=1 (namelist general) to proceed.'
-
 end module mod_chars

--- a/src/random.F90
+++ b/src/random.F90
@@ -542,8 +542,11 @@ module mod_random
 
 
       FUNCTION R1MACH()
-      IMPLICIT real(DP) (A-H,O-Z)
-      PARAMETER (ONE=1.D0,TWO=2.D0,HALF=0.5D0)
+      real(DP), parameter :: ONE=1.D0, TWO=2.D0, HALF=0.5D0
+      real(DP) :: R1MACH
+      real(DP) :: eps
+      real(DP) :: U, COMP
+      integer :: icall
       SAVE ICALL,EPS
       DATA ICALL,EPS/0,ONE/
 ! ---------------------------------------------------------------------

--- a/src/surfacehop.F90
+++ b/src/surfacehop.F90
@@ -1014,6 +1014,7 @@ contains
    end subroutine interpolate_dot
 
    subroutine check_energy(vx_old, vy_old, vz_old, vx, vy, vz, itrj)
+      use mod_interfaces, only: finish
       use mod_const, only: AUtoEV
       use mod_kinetic, only: ekin_v
       real(DP), intent(in) :: vx(:, :), vy(:, :), vz(:, :)

--- a/src/transform.F90
+++ b/src/transform.F90
@@ -326,6 +326,8 @@ contains
       real(DP) :: dnwalk, fac, equant
       integer :: nmodes, odd
 
+      dnwalk = 1.0D0
+      fac = 1.0D0
       if (inormalmodes == 1) then
          dnwalk = dsqrt(1.0D0 * nwalk)
          fac = dsqrt(2.0D0)
@@ -386,6 +388,8 @@ contains
       real(DP) :: dnwalk, fac
       integer :: nmodes, odd
 
+      dnwalk = 1.0D0
+      fac = 1.0D0
       if (inormalmodes == 1) then
          dnwalk = dsqrt(1.0D0 * nwalk)
          fac = dsqrt(2.0D0)

--- a/unit_tests/.gitignore
+++ b/unit_tests/.gitignore
@@ -5,6 +5,7 @@
 *.mod
 *.inc
 bck.*
+masses
 utils
 plumed
 plumed.out

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -12,7 +12,7 @@ ifneq ($(strip $(PFUNIT_PATH)),)
   include $(LATEST_PFUNIT_DIR)/include/PFUNIT.mk
   # TODO: Here we rewrite FFLAGS, but we should be reusing it
   # Need to figure out how to do test coverage separately
-  FFLAGS = $(PFUNIT_EXTRA_FFLAGS) -Wall -O0 -ffpe-trap=invalid,zero,overflow,denormal
+  FFLAGS = $(PFUNIT_EXTRA_FFLAGS) -Wall -Wno-maybe-uninitialized -O0 -ffpe-trap=invalid,zero,overflow,denormal
   FFLAGS += -I../src/
   FFLAGS += $(DFLAGS)
 endif
@@ -28,6 +28,13 @@ $(eval $(call make_pfunit_test,utils))
 
 utils_driver.o: throw_with_pfunit.o
 
+masses_TESTS := test_masses.pf
+masses_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}
+masses_OTHER_SRCS := throw_with_pfunit.F90
+masses_EXTRA_USE := throw_with_pfunit_mod
+masses_EXTRA_INITIALIZE := initialize_throw
+$(eval $(call make_pfunit_test,masses))
+
 plumed_TESTS := test_plumed.pf
 plumed_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}
 plumed_OTHER_SRCS := throw_with_pfunit.F90
@@ -42,18 +49,19 @@ fftw_EXTRA_USE := throw_with_pfunit_mod
 fftw_EXTRA_INITIALIZE := initialize_throw
 $(eval $(call make_pfunit_test,fftw))
 
-all : utils plumed fftw
+all : utils masses plumed fftw
 
 %.o : %.F90
 	$(FC) -c $(FFLAGS) $<
 
 test : clean_plumed_output
 	./utils
+	./masses
 	./plumed
 	./fftw
 
 clean : clean_plumed_output
-	/bin/rm -f *dat *.o *.out *.mod *.inc test_*.F90 utils plumed fftw
+	/bin/rm -f *dat *.o *.out *.mod *.inc test_*.F90 masses utils plumed fftw
 
 clean_plumed_output :
 	/bin/rm -f bck.* plumed_*.dat

--- a/unit_tests/test_fftw.pf
+++ b/unit_tests/test_fftw.pf
@@ -55,9 +55,13 @@ contains
    @test(ifndef=USE_FFTW)
    subroutine test_not_compiled_with_fftw()
       use, intrinsic :: iso_c_binding, only: C_DOUBLE, C_DOUBLE_COMPLEX
+      use mod_general, only: my_rank
       complex(C_DOUBLE_COMPLEX), dimension(1) :: normal_modes
       real(C_DOUBLE), dimension(1) :: xyz
       integer :: nbeads
+
+      ! To suppress output
+      my_rank = 1
 
       call fftw_normalmodes_init(nbeads)
       @assertExceptionRaised('ABIN was not compiled with FFTW library')

--- a/unit_tests/test_masses.pf
+++ b/unit_tests/test_masses.pf
@@ -1,0 +1,89 @@
+! Testing functions for initializing masses,
+! currently defined in module.F90
+module test_masses
+   use funit
+   use mod_utils
+   implicit none
+   integer, parameter :: NATOM = 3
+   real(DP) :: masses(NATOM)
+   character(len=2) :: massnames(NATOM)
+
+contains
+
+   ! This routine is called automatically before each test.
+   @before
+   subroutine setup()
+      use mod_general, only: my_rank
+      use mod_system, only: names
+      ! Setting this non-zero to prevent output to stdout
+      my_rank = 1
+      ! These are normally user-defined in the input file
+      massnames = ''
+      masses = -1.0D0
+      allocate (names(NATOM))
+   end subroutine setup
+
+   @after
+   subroutine teardown()
+      use mod_system, only: am, names
+      deallocate (am)
+      deallocate (names)
+   end subroutine teardown
+
+   @test
+   subroutine test_library_masses()
+      use mod_const, only: AMU
+      use mod_system, only: names, am, mass_init
+
+      names = (/'H', 'H', 'C'/)
+      call mass_init(masses, massnames, NATOM)
+      @assertEqual(1.008D0 * AMU, am(1), "hydrogen mass")
+      @assertEqual(1.008D0 * AMU, am(2), "hydrogen mass 2")
+      @assertEqual(12.0110D0 * AMU, am(3), "carbon mass")
+   end subroutine test_library_masses
+
+   @test
+   subroutine test_custom_masses()
+      use mod_const, only: AMU
+      use mod_system, only: names, am, mass_init
+
+      names = (/'H ', 'XY', 'C '/)
+      ! Here we override hydrogen mass, and define mass
+      ! for custom atomtype XY
+      massnames = (/'H ', 'XY', '  '/)
+      masses = (/2.0D0, 5.0D0, -1.0D0/)
+      call mass_init(masses, massnames, NATOM)
+      @assertEqual(2.0D0 * AMU, am(1), "custom deuterium mass")
+      @assertEqual(5.0D0 * AMU, am(2), "custom XY mass")
+      @assertEqual(12.0110D0 * AMU, am(3), "carbon mass from library")
+   end subroutine test_custom_masses
+
+   @test
+   subroutine test_not_specified()
+      use mod_system, only: names, mass_init
+      names = (/'H ', 'XY', 'C '/)
+      call mass_init(masses, massnames, NATOM)
+      @assertExceptionRaised('Atomic mass for atom XY was not specified')
+   end subroutine test_not_specified
+
+   @test
+   subroutine test_duplicates()
+      use mod_system, only: names, mass_init
+      names = (/'H ', 'XY', 'C '/)
+      massnames = (/'XY', 'XY', '  '/)
+      masses = (/2.0D0, 5.0D0, -1.0D0/)
+      call mass_init(masses, massnames, NATOM)
+      @assertExceptionRaised('Duplicate atom names in input array "massnames"')
+   end subroutine test_duplicates
+
+   @test
+   subroutine test_negative_mass()
+      use mod_system, only: names, mass_init
+      names = (/'H ', 'XY', 'C '/)
+      massnames = (/'XY', '  ', '  '/)
+      masses = (/-2.0D0, 5.0D0, -1.0D0/)
+      call mass_init(masses, massnames, NATOM)
+      @assertExceptionRaised('Mass cannot be negative. Fix arrays "masses" in the input file.')
+   end subroutine test_negative_mass
+
+end module test_masses


### PR DESCRIPTION
Adding `-fimplicit-none` to FFLAGS ensures that we always have `implicit none` in our modules and functions.
I fixed one missing `implicit none` (caught an unitialized variable!) and converted one last implicit typing in `random.F90`.

l also moved `mod_const` from `modules.F90` to a separate file `constants.F90` to break circular dependency due to the 'DP' constant. This allowed me reorder compilation of a some files and make 'fatal_error()' accessible to all modules. In general, our goal should be to have one module per file, so while I was in there, I also did the same for `mod_files`.

Other small changes were done to squash compiler warnings. I also did a bit of cleanup in `mass_init` and wrote some unit tests to verify this functionality (especially user defined masses code was messy and not fully tested).

Closes #76, Closes #63