### PR TITLE
Pin pFUnit version

### DIFF
--- a/dev_scripts/install_pfunit.sh
+++ b/dev_scripts/install_pfunit.sh
@@ -15,6 +15,10 @@ fi
 
 git clone --recursive https://github.com/Goddard-Fortran-Ecosystem/pFUnit $REPO_DIR && cd $REPO_DIR
 
+# This seems to be the last commit that works with GCC-7
+# Later commits fail with internal compiler error when compiling fArgParse submodule. 
+git checkout --recurse-submodules 0a09db354b665f1518e36460396c348c19185e04
+
 mkdir -p build && cd build
 export FC=gfortran
 export FFLAGS=


### PR DESCRIPTION
pFunit build started to fail with internal compiler error for GCC-7, see details in 

https://github.com/Goddard-Fortran-Ecosystem/pFUnit/issues/274#issuecomment-975740321