### PR TITLE
FIX TC Surface Hopping interface, broken since #62

### DIFF
--- a/src/force_tera.F90
+++ b/src/force_tera.F90
@@ -84,7 +84,7 @@ contains
 
       call send_atom_types_and_scrdir(names, natqm, iw, tc_comm, .true.)
 
-      call send_coordinates(x, y, z, natqm, iw, tc_comm)
+      call send_coordinates(x, y, z, natqm, iw, tc_comm, 'angstrom')
 
       ! NOT IMPLEMENTED !
       !if (natmm_tera > 0) then

--- a/src/force_terash.F90
+++ b/src/force_terash.F90
@@ -294,7 +294,7 @@ contains
       call MPI_Send(bufdoubles, 1, MPI_DOUBLE_PRECISION, 0, TC_TAG, tc_comm, ierr)
       call handle_mpi_error(ierr)
 
-      call send_coordinates(x, y, z, natqm, iw, tc_comm)
+      call send_coordinates(x, y, z, natqm, iw, tc_comm, 'bohr')
 
 !  Send previous diabatic MOs
       if (idebug > 0) write (*, *) 'Sending previous orbitals.', nbf * nbf
@@ -361,7 +361,7 @@ contains
 
       call send_atom_types_and_scrdir(names, natqm, iw, tc_comm, send_scrdir)
 
-      call send_coordinates(x, y, z, natqm, iw, tc_comm)
+      call send_coordinates(x, y, z, natqm, iw, tc_comm, 'bohr')
 
       ! START RECEIVING INFO FROM TeraChem.
       ! Receive nbf, CI length and blob size


### PR DESCRIPTION
While the Amber MPI interface that we use for classical MD
expects coordinates in angstromgs, the FMS interface expects bohr,
which I didn't notice when I was refactoring this code.
I really need to write those tests for the TC-SH interface.