### PR TITLE
Create MPI wrapper module

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -231,6 +231,7 @@ jobs:
   openmpi_build:
     name: OpenMPI build
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     needs: basic_build
     strategy:
       fail-fast: false

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-F_OBJS := constants.o fortran_interfaces.o error.o modules.o files.o utils.o io.o random.o arrays.o qmmm.o fftw_interface.o \
+F_OBJS := constants.o fortran_interfaces.o error.o modules.o files.o utils.o mpi_wrapper.o io.o random.o arrays.o qmmm.o fftw_interface.o \
           shake.o nosehoover.o gle.o transform.o potentials.o force_spline.o estimators.o ekin.o vinit.o plumed.o \
           remd.o force_bound.o water.o force_cp2k.o sh_integ.o surfacehop.o landau_zener.o\
           force_mm.o tera_mpi_api.o force_tera.o force_terash.o force_abin.o en_restraint.o analyze_ext_template.o geom_analysis.o analysis.o \

--- a/src/force_tera.F90
+++ b/src/force_tera.F90
@@ -16,6 +16,7 @@ module mod_force_tera
    use mod_terampi
 #ifdef USE_MPI
    use mpi
+   use mod_mpi, only: handle_mpi_error, check_recv_count
 #endif
    implicit none
    private

--- a/src/force_terash.F90
+++ b/src/force_terash.F90
@@ -43,7 +43,7 @@ contains
       use mod_const, only: DP, ANG
       use mod_array_size, only: NSTMAX
       use mod_general, only: idebug, natom, en_restraint, ipimd
-      use mod_terampi, only: handle_mpi_error, check_recv_count
+      use mod_mpi, only: handle_mpi_error, check_recv_count
       use mod_qmmm, only: natqm
       use mod_utils, only: abinerror
       use mod_io, only: print_charges, print_dipoles, print_transdipoles
@@ -208,7 +208,7 @@ contains
       use mod_terampi, only: send_coordinates
       use mod_array_size, only: NSTMAX
       use mod_const, only: DP, ANG, AUTOFS
-      use mod_terampi, only: handle_mpi_error
+      use mod_mpi, only: handle_mpi_error
       use mod_general, only: natom, idebug, sim_time, en_restraint
       use mod_qmmm, only: natqm
       use mod_utils, only: abinerror
@@ -321,8 +321,8 @@ contains
       use mod_system, only: names
       use mod_qmmm, only: natqm
       use mod_sh_integ, only: nstate
+      use mod_mpi, only: handle_mpi_error
       use mod_terampi, only: get_tc_communicator, &
-                             handle_mpi_error, &
                              send_natom, &
                              send_atom_types_and_scrdir, &
                              send_coordinates

--- a/src/init.F90
+++ b/src/init.F90
@@ -673,6 +673,8 @@ contains
 
    subroutine check_inputsanity()
       use mod_chars, only: chknow
+      use mod_utils, only: real_positive, real_nonnegative, &
+                         & int_positive, int_nonnegative, int_switch
       integer :: error
 !$    integer :: nthreads, omp_get_max_threads
 
@@ -722,7 +724,7 @@ contains
          end if
       end if
       if (pot == '_none_') then
-         write (*, *) 'FATAL: Variable "pot" not specified.Exiting now...'
+         write (*, *) 'ERROR: Variable "pot" not specified.'
          error = 1
       end if
       if (ipimd == 1 .and. nwalk <= 1) then
@@ -768,53 +770,12 @@ contains
       if (shiftdihed == 0) shiftdih = 0.0D0
       if (shiftdihed == 1) shiftdih = 360.0D0
 
-      if (imini < 0) then
-         write (*, *) 'Input error: imini must be positiv or zero.'
-         error = 1
-      end if
-      if (nstep < 0) then
-         write (*, *) 'Input error: nstep must be positive.'
-         error = 1
-      end if
-      if (nwrite <= 0) then
-         write (*, *) 'Input error: nwrite must be positive.'
-         error = 1
-      end if
-      if (nwritex <= 0) then
-         write (*, *) 'Input error: nwritex must be positive.'
-         error = 1
-      end if
-      if (nrest <= 0) then
-         write (*, *) 'Input error: nrest must be positive.'
-         error = 1
-      end if
-      if (nabin <= 0) then
-         write (*, *) 'Input error: nabin must be positive.'
-         error = 1
-      end if
-      if (icv /= 0 .and. icv /= 1) then
-         write (*, *) 'Input error: icv must be 1 or 0.'
-         error = 1
-      end if
-      if (temp < 0) then
-         write (*, *) 'Input error: temperature must be positive.'
-         error = 1
-      end if
       if (icv == 1 .and. temp <= 0.0D0) then
          write (*, *) 'Cannot compute heat capacity for zero temperature.'
          error = 1
       end if
       if (icv == 1 .and. inose == 0) then
          write (*, *) 'Cannot compute heat capacity for NVE simulation.'
-         error = 1
-      end if
-      if (dt <= 0) then
-         write (*, *) 'Time step negative or undefined!'
-         write (*, *) 'Modify variable "dt" in input the general input section.'
-         error = 1
-      end if
-      if (ncalc <= 0) then
-         write (*, *) 'Ncalc must be positive integer number!'
          error = 1
       end if
       if (ncalc > nwrite) then
@@ -837,10 +798,6 @@ contains
       end if
       if (ipimd == 5 .and. nwalk /= 1) then
          write (*, *) 'ERROR: LZ not implemented with multiple walkers.'
-         error = 1
-      end if
-      if (istage /= 1 .and. istage /= 0) then
-         write (*, *) 'ERROR: istage has to be 0 or 1'
          error = 1
       end if
       if (inormalmodes < 0 .and. inormalmodes > 2) then
@@ -929,10 +886,6 @@ contains
          write (*, *) 'The staging transformation is not compatible with GLE thermostat.'
          error = 1
       end if
-      if (irest /= 1 .and. irest /= 0) then
-         write (*, *) 'ERROR:irest has to be 1 or 0'
-         error = 1
-      end if
       if (nshake /= 0 .and. ipimd == 1) then
          write (*, *) 'PIMD with SHAKE cannot use massive thermostating!'
          error = 1
@@ -979,6 +932,26 @@ contains
             error = 1
          end if
       end if
+
+      call real_nonnegative(temp, 'temp')
+      call real_positive(dt, 'dt')
+
+      call int_switch(irest, 'irest')
+      call int_switch(icv, 'icv')
+      call int_switch(istage, 'istage')
+
+      call int_nonnegative(nstep, 'nstep')
+      call int_nonnegative(imini, 'imini')
+      call int_nonnegative(nwrite, 'nwrite')
+      call int_nonnegative(nwritex, 'nwritex')
+      call int_nonnegative(nwritev, 'nwritev')
+      call int_nonnegative(nwritef, 'nwritef')
+      call int_nonnegative(nrest, 'nrest')
+      call int_nonnegative(narchive, 'narchive')
+
+      call int_positive(nabin, 'nwalk')
+      call int_positive(nwalk, 'nwalk')
+      call int_positive(ncalc, 'ncalc')
 
       if (error == 1) then
          write (*, *) 'Input errors were found! Exiting now...'

--- a/src/mpi_wrapper.F90
+++ b/src/mpi_wrapper.F90
@@ -1,0 +1,191 @@
+! Wrapper functions for MPI calls.
+!  - MPI initialization / finalization
+!  - Common MPI function with proper error handling
+!  - MPI error handling helpers
+module mod_mpi
+#ifdef USE_MPI
+   use mpi
+#endif
+   private
+   public :: initialize_mpi, finalize_mpi
+   public :: mpi_barrier_wrapper
+   public :: get_mpi_rank, get_mpi_size
+
+#ifdef USE_MPI
+   public :: check_recv_count, handle_mpi_error
+   public :: get_mpi_error_string
+#endif
+
+contains
+
+#ifdef USE_MPI
+   subroutine initialize_mpi(pot, pot_ref, nteraservers)
+      character(len=*), intent(in) :: pot, pot_ref
+      integer, intent(in) :: nteraservers
+      logical :: initialized
+      integer :: ierr, ithread
+
+      call MPI_Initialized(initialized, ierr)
+      if (initialized) then
+         return
+      end if
+
+      if ((pot == "_tera_" .or. pot_ref == "_tera_") .and. nteraservers > 1) then
+         ! We will be calling TS servers concurently
+         ! via OpenMP parallelization, hence we need MPI_Init_thread().
+         ! https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node303.htm
+         call MPI_Init_thread(MPI_THREAD_MULTIPLE, ithread, ierr)
+         if (ierr /= 0) then
+            print*,'Bad signal from MPI_Init_thread:', ierr
+            stop 1
+         end if
+         if (ithread /= MPI_THREAD_MULTIPLE) then
+            write (*, *) 'Provided safety level is not MPI_THREAD_MULTIPLE'
+            write (*, '(A,I0,A,I0)') 'Requested ', MPI_THREAD_MULTIPLE, ' got: ', ithread
+            stop 1
+         end if
+      else
+         call MPI_Init(ierr)
+         if (ierr /= 0) then
+            write (*, *) 'Bad signal from MPI_INIT:', ierr
+            stop 1
+         end if
+      end if
+   end subroutine initialize_mpi
+
+   subroutine finalize_mpi(error_code)
+      integer, intent(in) :: error_code
+      logical :: initialized, finalized
+      integer :: ierr
+
+      call MPI_Initialized(initialized, ierr)
+      if (.not. initialized) then
+         return
+      end if
+
+      call MPI_Finalized(finalized, ierr)
+
+      if (error_code /= 0) then
+         call MPI_Abort(MPI_COMM_WORLD, error_code, ierr)
+      else if (.not. finalized) then
+         call MPI_Finalize(ierr)
+      end if
+   end subroutine
+
+   function get_mpi_error_string(mpi_err) result(error_string)
+      integer, intent(in) :: mpi_err
+      character(len=MPI_MAX_ERROR_STRING) :: error_string
+      integer :: result_len
+      integer :: ierr
+
+      call MPI_Error_string(mpi_err, error_string, result_len, ierr)
+      if (ierr /= MPI_SUCCESS) then
+         error_string = 'Unspecified MPI error'
+      end if
+   end function get_mpi_error_string
+
+   subroutine handle_mpi_error(mpi_err)
+      use mod_error, only: fatal_error
+      integer, intent(in) :: mpi_err
+
+      if (mpi_err /= MPI_SUCCESS) then
+         call fatal_error(__FILE__, __LINE__, get_mpi_error_string(mpi_err))
+      end if
+   end subroutine handle_mpi_error
+
+   subroutine check_recv_count(mpi_status, expected_count, datatype)
+      use mod_error, only: fatal_error
+      integer, intent(in) :: mpi_status(:)
+      integer, intent(in) :: expected_count
+      integer, intent(in) :: datatype ! e.g. MPI_INTEGER
+      character(len=100) :: error_msg
+      integer :: recv_count
+      integer :: ierr
+
+      call MPI_Get_count(mpi_status, datatype, recv_count, ierr)
+      call handle_mpi_error(ierr)
+      if (recv_count /= expected_count) then
+         write (error_msg, '(A,I0,A,I0)') 'Unexpected MPI_Recv count.&
+            & Received ', recv_count, ' bytes, expected ', expected_count
+         call fatal_error(__FILE__, __LINE__, error_msg)
+      end if
+   end subroutine check_recv_count
+
+   subroutine mpi_barrier_wrapper(communicator)
+      integer, intent(in), optional :: communicator
+      integer :: comm
+      integer :: ierr
+
+      comm = MPI_COMM_WORLD
+      if (present(communicator)) then
+         comm = communicator
+      end if
+
+      call MPI_Barrier(comm, ierr)
+      call handle_mpi_error(ierr)
+   end subroutine mpi_barrier_wrapper
+
+   integer function get_mpi_size(communicator) result(mpi_size)
+      integer, intent(in), optional :: communicator
+      integer :: comm
+      integer :: ierr
+
+      comm = MPI_COMM_WORLD
+      if (present(communicator)) then
+         comm = communicator
+      end if
+
+      call MPI_Comm_size(MPI_COMM_WORLD, mpi_size, ierr)
+      call handle_mpi_error(ierr)
+   end function get_mpi_size
+
+   integer function get_mpi_rank(communicator) result(rank)
+      integer, intent(in), optional :: communicator
+      integer :: comm
+      integer :: ierr
+
+      comm = MPI_COMM_WORLD
+      if (present(communicator)) then
+         comm = communicator
+      end if
+
+      call MPI_Comm_rank(comm, rank, ierr)
+      call handle_mpi_error(ierr)
+   end function get_mpi_rank
+
+#else
+
+   subroutine initialize_mpi(pot, pot_ref, nteraservers)
+      use mod_utils, only: not_compiled_with
+      use mod_general, only: iremd
+      character(len=*), intent(in) :: pot, pot_ref
+      integer, intent(in) :: nteraservers
+      integer :: i
+      i = nteraservers
+      if (iremd == 1 .or. &
+        & pot == '_tera_' .or. pot_ref == '_tera_' .or. &
+        & pot == '_cp2k_' .or. pot_ref == '__cp2k__') then
+         call not_compiled_with('MPI')
+      end if
+   end subroutine initialize_mpi
+
+   subroutine finalize_mpi(error_code)
+      integer, intent(in) :: error_code
+      integer :: e
+      e = error_code
+   end subroutine finalize_mpi
+
+   subroutine mpi_barrier_wrapper()
+   end subroutine mpi_barrier_wrapper
+
+   integer function get_mpi_rank() result(rank)
+      rank = 0
+   end function get_mpi_rank
+
+   integer function get_mpi_size() result(mpi_size)
+      mpi_size = 1
+   end function get_mpi_size
+
+#endif
+
+end module mod_mpi

--- a/src/water.F90
+++ b/src/water.F90
@@ -6,6 +6,7 @@ module mod_water
    save
 contains
    subroutine check_water(natom, names)
+      use mod_general, only: my_rank
       use mod_utils, only: abinerror, count_atoms_by_name
       integer, intent(in) :: natom
       character(len=2) :: names(:)
@@ -23,7 +24,7 @@ contains
 
       error = 0
 
-      write (*, *) 'Checking that input atom types correspond to pure water.'
+      if (my_rank == 0) print*,'Checking that input atom types correspond to pure water.'
 
       ! Note that some of these checks are redundant,
       ! but we're trying to be helpful and provide as much info as we can.
@@ -53,7 +54,7 @@ contains
          call abinerror('check_water')
       end if
 
-      print '(A,I0,A)', 'Detected ', nO, ' water molecules'
+      if (my_rank == 0) print '(A,I0,A)', 'Detected ', nO, ' water molecules'
    end subroutine check_water
 
 end module mod_water

--- a/tests/REMD/input.in
+++ b/tests/REMD/input.in
@@ -19,6 +19,7 @@ temp=100.15,
 nrespnose=8
 rem_comrot=.false.
 rem_comvel=.false.
+tau0=0.001D0
 /
 
 &remd

--- a/tests/REMD/input.in2
+++ b/tests/REMD/input.in2
@@ -17,6 +17,7 @@ irest=1,
 inose=1,
 temp=100.15,
 nrespnose=8
+tau0=0.001D0
 /
 
 &remd

--- a/tests/REMD/input.in3
+++ b/tests/REMD/input.in3
@@ -17,6 +17,7 @@ irest=1,
 inose=1,
 temp=100.15,
 nrespnose=8
+tau0=0.001D0
 /
 
 &remd

--- a/tests/REMD/test.sh
+++ b/tests/REMD/test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-rm -f remd.out abin.out restart.xyz.??.old restart.xyz.?? restart.xyz.??.? geom.dat.?? movie.xyz.?? cp2k.out temper.dat.?? energies.dat.??
+rm -f EXIT ERROR remd.out abin.out restart.xyz.??.old restart.xyz.?? restart.xyz.??.? geom.dat.?? movie.xyz.?? cp2k.out temper.dat.?? energies.dat.??
 if [[ "$1" = "clean" ]];then
    exit 0
 fi
@@ -31,6 +31,7 @@ $MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}2 >> $ABINOUT
 # Test that ABIN stops when file EXIT is present
 touch EXIT
 $MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}3 >> $ABINOUT
+rm -f EXIT
 
 # Useful line in case you need to debug multiple MPI processes
 # $MPIRUN -np $N_REPLICAS xterm -e gdb $ABINEXE -i $ABININ -v $ABINVEL > $ABINOUT

--- a/tests/TERAPI-FAILS/ABIN_ERROR4.ref
+++ b/tests/TERAPI-FAILS/ABIN_ERROR4.ref
@@ -1,2 +1,1 @@
- FATAL ERROR encountered in subroutine: handle_mpi_error
- Check standard output for further information.
+ERROR in mpi_wrapper.F90: Message truncated, error stack:

--- a/tests/TERAPI-FAILS/ABIN_ERROR8.ref
+++ b/tests/TERAPI-FAILS/ABIN_ERROR8.ref
@@ -1,2 +1,1 @@
- FATAL ERROR encountered in subroutine: check_recv_count
- Check standard output for further information.
+ERROR in mpi_wrapper.F90: Unexpected MPI_Recv count. Received 0 bytes, expected 1

--- a/tests/TERAPI-FAILS/test.sh
+++ b/tests/TERAPI-FAILS/test.sh
@@ -42,6 +42,9 @@ echo "########### SUBTEST 3 ###################"
 ./test3.sh
 echo "########### SUBTEST 4 ###################"
 ./test4.sh
+# Getting rid of varible MPI trace
+head -1 ABIN_ERROR4 > tmp
+mv tmp ABIN_ERROR4
 echo "########### SUBTEST 5 ###################"
 ./test5.sh
 echo "########### SUBTEST 6 ###################"


### PR DESCRIPTION
The idea here is to centralize certain calls to MPI library in one place, with proper error handling.
This should reduce the amount of `#ifdef USE_MPI` throughout the codebase.

We also encapsule MPI initialization and finalization, and provide helper functions for error handling.