### PR TITLE
Fix the code coverage for mpi error paths

### DIFF
--- a/tests/REMD/ERROR.ref
+++ b/tests/REMD/ERROR.ref
@@ -1,0 +1,1 @@
+ERROR in remd.F90: Number of MPI processes does not match number of REMD replicas.

--- a/tests/REMD/test.sh
+++ b/tests/REMD/test.sh
@@ -26,12 +26,15 @@ fi
 N_REPLICAS=$(egrep --only-matching 'nreplica\s*=\s*[0-9]' $ABININ | egrep -o [0-9])
 
 $MPIRUN -np $N_REPLICAS $ABINEXE -i $ABININ -v $ABINVEL > $ABINOUT
-$MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}2 >> $ABINOUT
+$MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}2 > ${ABINOUT}2
 
 # Test that ABIN stops when file EXIT is present
 touch EXIT
-$MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}3 >> $ABINOUT
+$MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}3 > ${ABINOUT}3
 rm -f EXIT
+
+# This should error out since number of MPI processes is wrong
+$MPIRUN -np 2 $ABINEXE -i ${ABININ}2 > ${ABINOUT}4 2>&1
 
 # Useful line in case you need to debug multiple MPI processes
 # $MPIRUN -np $N_REPLICAS xterm -e gdb $ABINEXE -i $ABININ -v $ABINVEL > $ABINOUT


### PR DESCRIPTION
Follow-up on #97. Do not call `MPI_Abort()` for TC-MPI interface, since it screws up code coverage for some reason (very strange :scream:), and it is not needed anyway since we only have one MPI process.

Add a test case for failing REMD.

Also minor cleanup in `remd_init()`.