### PR TITLE
GHA: support Plumed 2.8

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -294,8 +294,6 @@ jobs:
       CFLAGS: -O0
       CXXLAGS: -O0
       CODECOV_NAME: ${{format('{0} GCC-{1} PLUMED-{2}', github.job, matrix.gcc_v, matrix.plumed_v)}}
-      # Compatibility with Plumed 2.8.0
-      PLUMED_DP2CUTOFF_NOSTRETCH: 1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -284,7 +284,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         plumed_v: [2.5.3, 2.6.2, 2.7.0]
+         plumed_v: [2.5.3, 2.6.2, 2.8.0]
          gcc_v: [7]
 
     env:
@@ -294,6 +294,8 @@ jobs:
       CFLAGS: -O0
       CXXLAGS: -O0
       CODECOV_NAME: ${{format('{0} GCC-{1} PLUMED-{2}', github.job, matrix.gcc_v, matrix.plumed_v)}}
+      # Compatibility with Plumed 2.8.0
+      PLUMED_DP2CUTOFF_NOSTRETCH: 1
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/PLUMED/test.sh
+++ b/tests/PLUMED/test.sh
@@ -1,0 +1,20 @@
+#/bin/bash
+
+rm -f EXIT ERROR plumed_*.dat abin.out* bck.0.plumed.out
+if [[ "$1" = "clean" ]];then
+   exit 0
+fi
+
+ABINEXE=$1
+ABININ=input.in
+ABINOUT=abin.out
+
+# This is needed for compatibility with new Plumed 2.8
+# See: https://github.com/plumed/plumed2/pull/757
+export PLUMED_DP2CUTOFF_NOSTRETCH=1
+
+$ABINEXE -i $ABININ -x mini.xyz > $ABINOUT
+$ABINEXE -i ${ABININ}2  -x mini.xyz > ${ABINOUT}2
+
+# Compatibility for Plumed 2.8
+sed -i 's/stretched-gaussian/gaussian/' plumed_hills.dat

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -35,6 +35,8 @@ masses_EXTRA_USE := throw_with_pfunit_mod
 masses_EXTRA_INITIALIZE := initialize_throw
 $(eval $(call make_pfunit_test,masses))
 
+# This is needed for compatibility with new Plumed 2.8
+# See: https://github.com/plumed/plumed2/pull/757
 export PLUMED_DP2CUTOFF_NOSTRETCH = 1
 
 plumed_TESTS := test_plumed.pf
@@ -89,9 +91,6 @@ $(eval $(call make_pfunit_test,spline))
 all : utils masses plumed fftw terapi gle nhc pot spline
 
 %.o : %.F90
-	$(FC) -c $(FFLAGS) $<
-
-test_plumed.o : test_plumed.F90
 	$(FC) -c $(FFLAGS) $<
 
 test : clean_plumed_output clean_terapi_output clean_gle_output

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -35,6 +35,8 @@ masses_EXTRA_USE := throw_with_pfunit_mod
 masses_EXTRA_INITIALIZE := initialize_throw
 $(eval $(call make_pfunit_test,masses))
 
+export PLUMED_DP2CUTOFF_NOSTRETCH = 1
+
 plumed_TESTS := test_plumed.pf
 plumed_OTHER_LIBRARIES := -lgcov -fprofile-arcs -L"../src/" -labin -L"../water_potentials/" -lwater ${LIBS}
 plumed_OTHER_SRCS := throw_with_pfunit.F90
@@ -87,6 +89,9 @@ $(eval $(call make_pfunit_test,spline))
 all : utils masses plumed fftw terapi gle nhc pot spline
 
 %.o : %.F90
+	$(FC) -c $(FFLAGS) $<
+
+test_plumed.o : test_plumed.F90
 	$(FC) -c $(FFLAGS) $<
 
 test : clean_plumed_output clean_terapi_output clean_gle_output

--- a/unit_tests/test_plumed.pf
+++ b/unit_tests/test_plumed.pf
@@ -8,8 +8,6 @@ module test_plumed
    integer, parameter :: NATOMS = 2, NBEADS = 1
    real(DP) :: x(NATOMS, NBEADS), y(NATOMS, NBEADS), z(NATOMS, NBEADS)
    real(DP) :: fx(NATOMS, NBEADS), fy(NATOMS, NBEADS), fz(NATOMS, NBEADS)
-   ! Passed to the PLUMED constructor so that it doesn't print extra info.
-   logical, parameter :: SILENT = .true.
    integer :: iunit
    save
 
@@ -20,6 +18,7 @@ contains
    ! This routine is called automatically before each test.
    @before
    subroutine setup()
+      use mod_files, only: stdout_to_devnull
       use mod_general, only: natom, nwalk, dt0, it
       use mod_system, only: am
       use mod_nhc, only: temp
@@ -41,16 +40,17 @@ contains
       open (newunit=iunit, file=plumedfile, access='sequential')
       close (unit=iunit)
 
+      call stdout_to_devnull()
       ! NOTE: Some tests might need to call plumed_init() again,
       ! e.g. if they need to re-define the time step.
-      ! It seems it's okay to call it multiple times though.
-      ! Because we need to be able to setup initial variables before each test.
-      call plumed_init(SILENT)
+      ! In that case, call plumed_finalize() before calling plumed_init() again.
+      call plumed_init()
    end subroutine setup
 
    ! This routine is called automatically after each test.
    @after
    subroutine teardown()
+      use mod_files, only: reset_stdout
       use mod_system, only: am
       deallocate (am)
       ! Delete auxiliary PLUMED input file.
@@ -64,6 +64,7 @@ contains
       ! It's okay to call it multiple times though, see how it is
       ! defined in src/plumed.F90.
       call finalize_plumed()
+      call reset_stdout()
    end subroutine teardown
 
    ! Here we just test we can initialize and finalize PLUMED without dying,
@@ -95,7 +96,8 @@ contains
       dt0 = 1.0D3 / AUTOFS
 
       ! Need to call plumed_init() again since we redefined dt
-      call plumed_init(SILENT)
+      call finalize_plumed()
+      call plumed_init()
       call plumed_f_gcmd('readInputLine'//char(0), DISTANCE_ACTION)
       call plumed_f_gcmd('readInputLine'//char(0), PRINT_ACTION)
 


### PR DESCRIPTION
Closes #83.

Plumed 2.8 fails one unit test and the METAD test because Plumed started using stretched gaussians, which leads to numerical differences.

See https://github.com/plumed/plumed2/issues/420 and https://github.com/plumed/plumed2/pull/757. As a quick fix for our test suite, we can set env variable PLUMED_DP2CUTOFF_NOSTRETCH before the linking step.