### PR TITLE
SH: Remove itrj index from all arrays

### DIFF
--- a/src/abin.F90
+++ b/src/abin.F90
@@ -24,7 +24,7 @@ program abin
    use mod_general, only: sim_time, pot, pot_ref, iremd, ipimd, &
       & md, nwrite, nstep, ncalc, it, inormalmodes, istage, irest
    use mod_init, only: init
-   use mod_sh, only: surfacehop, ntraj, sh_init, get_nacm, move_vars
+   use mod_sh, only: surfacehop, sh_init, get_nacm, move_vars
    use mod_lz, only: lz_hop, en_array_lz, lz_rewind
    use mod_kinetic, only: temperature
    use mod_utils, only: abinerror, archive_file, get_formatted_date_and_time
@@ -41,7 +41,6 @@ program abin
    implicit none
    ! TODO: These should probably be defined and stored in some module, not here
    real(DP) :: dt = 20.0D0, eclas = 0.0D0, equant = 0.0D0
-   integer :: itrj
    logical :: file_exists
    integer, dimension(8) :: time_start, time_end
    integer :: my_rank
@@ -119,15 +118,13 @@ program abin
 
       ! setting initial values for surface hopping
       if (ipimd == 2) then
-         do itrj = 1, ntraj
-            if (irest /= 1) then
-               call get_nacm(itrj)
-            end if
-            call move_vars(vx, vy, vz, vx_old, vy_old, vz_old, itrj)
-            if (pot == '_tera_' .or. restrain_pot == '_tera_') then
-               call move_new2old_terash()
-            end if
-         end do
+         if (irest /= 1) then
+            call get_nacm()
+         end if
+         call move_vars(vx, vy, vz, vx_old, vy_old, vz_old)
+         if (pot == '_tera_' .or. restrain_pot == '_tera_') then
+            call move_new2old_terash()
+         end if
       else if (ipimd == 5 .and. pot == '_tera_') then
          call move_new2old_terash()
       end if

--- a/src/analysis.F90
+++ b/src/analysis.F90
@@ -206,7 +206,7 @@ contains
       use mod_estimators
       use mod_kinetic, only: entot_cumul, est_temp_cumul
       use mod_sh_integ, only: sh_write_wf
-      use mod_sh, only: write_nacmrest, ntraj, istate
+      use mod_sh, only: write_nacmrest, istate
       use mod_lz, only: lz_restout
       use mod_gle, only: gle_restout, pile_restout
       use mod_random
@@ -214,7 +214,7 @@ contains
       real(DP), intent(in) :: x(:, :), y(:, :), z(:, :)
       real(DP), intent(in) :: vx(:, :), vy(:, :), vz(:, :)
       integer, intent(in) :: time_step
-      integer :: iat, iw, itrj
+      integer :: iat, iw
       integer :: my_rank
       logical :: file_exists
       character(len=200) :: chout, chsystem
@@ -267,11 +267,9 @@ contains
 
       if (ipimd == 2) then
          call write_nacmrest()
-         ! hack, only one trajectory supported at this point
-         itrj = 1
          write (102, *) chSH
-         write (102, *) istate(itrj)
-         call sh_write_wf(102, itrj)
+         write (102, *) istate
+         call sh_write_wf(102)
       end if
 
       if (ipimd == 5) then
@@ -330,7 +328,7 @@ contains
       use mod_estimators
       use mod_kinetic, only: entot_cumul, est_temp_cumul
       use mod_sh_integ, only: sh_read_wf
-      use mod_sh, only: write_nacmrest, ntraj, istate
+      use mod_sh, only: write_nacmrest, istate
       use mod_lz, only: lz_restin
       use mod_gle, only: gle_restin, pile_restin
       use mod_random
@@ -338,7 +336,7 @@ contains
       real(DP), intent(out) :: x(:, :), y(:, :), z(:, :)
       real(DP), intent(out) :: vx(:, :), vy(:, :), vz(:, :)
       integer, intent(out) :: it
-      integer :: iat, iw, itrj
+      integer :: iat, iw
       integer :: my_rank
       character(len=100) :: chtemp
       logical :: prngread
@@ -378,10 +376,8 @@ contains
       if (ipimd == 2) then
          read (111, '(A)') chtemp
          call checkchar(chtemp, chsh)
-         ! only 1 trajectory supported at this point
-         itrj = 1
-         read (111, *) istate(itrj)
-         call sh_read_wf(111, itrj)
+         read (111, *) istate
+         call sh_read_wf(111)
       end if
 
       if (ipimd == 5) then

--- a/src/en_restraint.F90
+++ b/src/en_restraint.F90
@@ -68,8 +68,8 @@ contains
                fyes(iat) = fyr(iat, 2)
                fzes(iat) = fzr(iat, 2)
             end do
-            eclasground = en_array(1, 1)
-            eclasexc = en_array(2, 1)
+            eclasground = en_array(1)
+            eclasexc = en_array(2)
             ! TODO: need to figure out how to get eclasexc
          else
 

--- a/src/force_abin.F90
+++ b/src/force_abin.F90
@@ -157,11 +157,11 @@ subroutine force_abin(x, y, z, fx, fy, fz, eclas, chpot, walkmax)
 ! SH
       ! TODO: Have each state in different file?
       if (ipimd == 2) then
-         en_array(1, iw) = temp1
+         en_array(1) = temp1
          do ist1 = 2, nstate
-            read (MAXUNITS + iw, *) en_array(ist1, iw)
+            read (MAXUNITS + iw, *) en_array(ist1)
          end do
-         eclas = en_array(istate(iw), iw)
+         eclas = en_array(istate)
       end if
 ! LZ
       if (ipimd == 5) then
@@ -182,7 +182,7 @@ subroutine force_abin(x, y, z, fx, fy, fz, eclas, chpot, walkmax)
       end if
 
       if (ipimd == 2) then
-         iost = read_forces(fx, fy, fz, natqm, tocalc(istate(iw), istate(iw)), MAXUNITS + iw)
+         iost = read_forces(fx, fy, fz, natqm, tocalc(istate, istate), MAXUNITS + iw)
       else if (ipimd == 5) then
          iost = read_forces(fx, fy, fz, natqm, tocalc_lz(istate_lz), MAXUNITS + iw) !Save only the computed state
       else

--- a/src/init.F90
+++ b/src/init.F90
@@ -404,7 +404,7 @@ subroutine init(dt)
    ! Selecting proper integrator for a given MD type
    ! (controlled by variable 'md')
    if (ipimd == 2 .or. ipimd == 5) then
-      nwalk = ntraj !currently 1
+      nwalk = 1
       md = 2 ! velocity verlet
       nabin = 1
    else if (ipimd == 1 .and. inormalmodes /= 1) then

--- a/src/landau_zener.F90
+++ b/src/landau_zener.F90
@@ -12,7 +12,7 @@ module mod_lz
    use mod_const, only: DP
    use mod_utils, only: abinerror
    use mod_general, only: nwalk, pot, irest
-   use mod_array_size, only: NSTMAX, NTRAJMAX
+   use mod_array_size, only: NSTMAX
    use mod_sh, only: istate_init, istate, inac !TERA-MPI interface
    use mod_sh_integ, only: nstate
    implicit none
@@ -106,7 +106,7 @@ contains
 
       !TODO: energy drift
       call check_energy_lz(en_array_lz, istate_lz, energydifthr_lz)
-      !call check_energydrift(vx, vy, vz, itrj)
+      !call check_energydrift(vx, vy, vz)
 
       !Current state
       ist = istate_lz

--- a/src/modules.F90
+++ b/src/modules.F90
@@ -12,7 +12,7 @@ module mod_array_size
    implicit none
    public
    integer, parameter :: MAXTYPES = 10
-   integer, parameter :: NSTMAX = 50, NTRAJMAX = 1
+   integer, parameter :: NSTMAX = 50
    save
 end module mod_array_size
 


### PR DESCRIPTION
This was never useful, and if we ever need to run SH trajectories in parallel, it will be better accomplished with MPI.