### PR TITLE
Fix restart from old restart files

### DIFF
--- a/src/analysis.F90
+++ b/src/analysis.F90
@@ -409,7 +409,7 @@ contains
 
          do iw = 1, nwalk
             do iat = 1, natom
-               read (urest, '(3ES25.16E3)') x(iat, iw), y(iat, iw), z(iat, iw)
+               read (urest, *) x(iat, iw), y(iat, iw), z(iat, iw)
             end do
          end do
       end subroutine read_xyz


### PR DESCRIPTION
Explicitly specifying a format for floats in `read` statements apparently leads to runtime errors if the number is in a different format (e.g. in old restart file) so we cannot use it.