### PR TITLE
Interface for Landau-Zener SH with MNDO program

### DIFF
--- a/interfaces/MNDO-LZ/mndo.inp
+++ b/interfaces/MNDO-LZ/mndo.inp
@@ -9,9 +9,9 @@ multi=0		# Multiplicity
               		# 1 Open-shell singlet with two singly occupied orbitals, this usually corresponds to an excited singlet state
               		# 2 Doublet
               		# 3 Triplet
-occ=6           # Number of highest occupied orbitals
-unocc=7         # Number of lowest unoccupied orbitals
-initstate=2     # Inital state
+occ=3           # Number of highest occupied orbitals
+unocc=3         # Number of lowest unoccupied orbitals
+initstate=2     # Initial state (1 - Ground state, 2 - 1st Excited state, and so on ...)
 levelexc=2	# Maximum excitation level
 			# 1 CIS
 			# 2 CISD

--- a/interfaces/MNDO-LZ/mndo.inp
+++ b/interfaces/MNDO-LZ/mndo.inp
@@ -1,0 +1,35 @@
+# ----------------------------------------------------------
+# ---------------------- USER SETUP ------------------------
+# ----------------------------------------------------------
+
+method=OM3	# ODM3, ODM2, MNDO/d, OM3, PM3, OM2, OM1, AM1, MNDOC, MNDO, MINDO/3, CNDO/2, SCC-DTFB, 6 (SCC-DFTB with additional params), -3 (MNDO/H), -13 (MNDO/dH)  
+charge=0	# Molecular charge
+multi=0		# Multiplicity
+              		# 0 Closed-shell singlet
+              		# 1 Open-shell singlet with two singly occupied orbitals, this usually corresponds to an excited singlet state
+              		# 2 Doublet
+              		# 3 Triplet
+occ=6           # Number of highest occupied orbitals
+unocc=7         # Number of lowest unoccupied orbitals
+initstate=2     # Inital state
+levelexc=2	# Maximum excitation level
+			# 1 CIS
+			# 2 CISD
+			# 3 CISDT
+			# 4 CISDTQ
+			# n Up to n-fold excitations
+disper=-1     	# Dispersion function corrections (only for AM1, PM3, OM2, OM3, ODM2, and ODM3)
+              			# -1 not included
+              			#  0 equivalent to -1 except for ODM2 and ODM3 
+              		# for AM1 and PM3:
+              			#  1  Include dispersion corrections (PCCP 9, 2362 (2007)).
+              		# for OM2 and OM3:
+              			#  1  Like immdp=2 with Elstner's damping function alias D1
+              			#  2  Include the D2 dispersion correction from Grimme with Yang's damping function
+              		# for OM2, OM3, ODM2, and ODM3:
+              			#  3  Include the D3 dispersion correction from Grimme with Becke-Johnson damping and without three-body terms
+              			# -3  Like immdp=3, but with three-body terms included.
+
+# ----------------------------------------------------------
+# --------------------- END OF SETUP -----------------------
+# ----------------------------------------------------------

--- a/interfaces/MNDO-LZ/r.mndo-lz
+++ b/interfaces/MNDO-LZ/r.mndo-lz
@@ -14,8 +14,10 @@ timestep=$1
 ibead=$2
 input=input$ibead
 geom=../geom.dat.$ibead
-natom=$(cat $geom | wc -l )
+natom=$(wc -l < $geom)
 
+# advanced option, should be changed carefully
+# main options are in "mndo.inp"
 comment1="Timestep $timestep"	# Optional comment
 comment2=""	# Optional comment
 jop="-2" 	# Type of the calcuation
@@ -25,9 +27,6 @@ nsav15=3	# Compulsory: Prints desired output file
 ipubo=1		# Compulsory: Saves wavefunction
 ktrial=11	# Compulsory: Loads wavefunction
 ifast=2         # Fast diagonalizations in SCF (0 - Allowed, 1 - Allowed after init full diagonalization, 2 - Not allowed)
-
-cp ../engrad.dat.$ibead ../engrad.dat.$ibead.old
-rm -f ../engrad.dat.$ibead
 
 # -------------- DETERMINING CURRENT STATE -----------------
 
@@ -52,8 +51,6 @@ EOF
 # It uses dummy atoms for small molecules otherwise it switches automatically from XYZ to Z-Matrix format
 
 awk '
-BEGIN{
-}
 {
    printf "%s %.12g %i %.12g %i %.12g %i\n", $1, $2, 1,  $3, 1,  $4, 1
 }
@@ -73,24 +70,12 @@ if [[ $? -ne 0 ]] || ! $( grep -q "COMPUTATION TIME" $input.out ) || ! $( grep -
    echo "WARNING from r.mndo: MNDO calculation probably failed."
    echo "See $input.out.error"
    cp $input.out $input.out.error
+   exit 2
 fi
 
 # ------------------- DATA EXTRACTION ---------------------- 
 
-grep -e 'Dipole-length electric dipole transition moments' -A `expr $lroot + 1`  $input.out | tail -1 |  \
-awk '
-	BEGIN {
-		AUtoD=2.541746473
-	}
-	{
-		print $4;
-		print $6/AUtoD, $7/AUtoD, $8/AUtoD
-	}
-' >> ../rawdata.dat
-
-
 grep 'State  ' $input.out | awk '{printf "%.8f\n\n", $9/27.211396}' > ../engrad.dat.$ibead
-
 
 grep -A$(($natom*3))  'INTERNAL COORDINATES AND GRADIENTS'  fort.15 | tail -n +2 | awk '
 	BEGIN{toAU=0.000843297}

--- a/interfaces/MNDO-LZ/r.mndo-lz
+++ b/interfaces/MNDO-LZ/r.mndo-lz
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# MNDO/Landau-Zener Surface Hopping Interface for ABIN
+# Created by M. Belina, J. Janos and J. Polena
+
+cd MNDO-LZ
+
+# ------------------ LOADING VARIABLES ---------------------
+
+source SetEnvironment.sh MNDO
+source mndo.inp
+
+timestep=$1
+ibead=$2
+input=input$ibead
+geom=../geom.dat.$ibead
+natom=$(cat $geom | wc -l )
+
+comment1="Timestep $timestep"	# Optional comment
+comment2=""	# Optional comment
+jop="-2" 	# Type of the calcuation
+igeom=1		# 0 - Internal coordinates, 1 - Cartesian coordinates
+iform=1 	# Type of input format
+nsav15=3	# Compulsory: Prints desired output file
+ipubo=1		# Compulsory: Saves wavefunction
+ktrial=11	# Compulsory: Loads wavefunction
+ifast=2         # Fast diagonalizations in SCF (0 - Allowed, 1 - Allowed after init full diagonalization, 2 - Not allowed)
+
+cp ../engrad.dat.$ibead ../engrad.dat.$ibead.old
+rm -f ../engrad.dat.$ibead
+
+# -------------- DETERMINING CURRENT STATE -----------------
+
+# Reading from state.dat
+# Number of states and state we are on 
+read -t 2 -a nstate
+read -t 2 -a tocalc
+read -t 1 -a nsinglet		# or doublet, just multiplicity of ground state
+read -t 1 -a ntriplet		# (not used) 
+
+# ---------------------- MNDO INPUT ------------------------
+
+cat > $input << EOF
+$method jop=$jop igeom=$igeom iform=$iform nsav15=$nsav15 kharge=$charge imult=$multi +
+ipubo=$ipubo ktrial=$ktrial immdp=$disper kci=5 ici1i=$occ ici2=$unocc lroot=$tocalc iroot=$nstate +
+nciref=1 mciref=3 levexc=$levelexc ioutci=1 kitscf=1500 iuvcd=2 ifast=$ifast
+$comment1
+$comment2
+EOF
+
+# Conversion of XYZ input to MNDO geom
+# It uses dummy atoms for small molecules otherwise it switches automatically from XYZ to Z-Matrix format
+
+awk '
+BEGIN{
+}
+{
+   printf "%s %.12g %i %.12g %i %.12g %i\n", $1, $2, 1,  $3, 1,  $4, 1
+}
+END {
+   for (i = 1; i <= 4 - NR; i++)
+        print 99, 0, 0, 0, 0, 0, 0
+}
+' $geom >> $input
+
+# ---------------------- JOB LAUNCH ------------------------
+
+$MNDOEXE < $input &> $input.out
+
+# --------------------- ERROR CHECK ------------------------
+
+if [[ $? -ne 0 ]] || ! $( grep -q "COMPUTATION TIME" $input.out ) || ! $( grep -q "SCF TOTAL ENERGY" $input.out ) ;then
+   echo "WARNING from r.mndo: MNDO calculation probably failed."
+   echo "See $input.out.error"
+   cp $input.out $input.out.error
+fi
+
+# ------------------- DATA EXTRACTION ---------------------- 
+
+grep -e 'Dipole-length electric dipole transition moments' -A `expr $lroot + 1`  $input.out | tail -1 |  \
+awk '
+	BEGIN {
+		AUtoD=2.541746473
+	}
+	{
+		print $4;
+		print $6/AUtoD, $7/AUtoD, $8/AUtoD
+	}
+' >> ../rawdata.dat
+
+
+grep 'State  ' $input.out | awk '{printf "%.8f\n\n", $9/27.211396}' > ../engrad.dat.$ibead
+
+
+grep -A$(($natom*3))  'INTERNAL COORDINATES AND GRADIENTS'  fort.15 | tail -n +2 | awk '
+	BEGIN{toAU=0.000843297}
+	NR%3==1{gradx=$4*toAU}
+	NR%3==2{grady=$4*toAU}
+	NR%3==0{gradz=$4*toAU; printf"%.12f %.12f %.12f\n",gradx,grady,gradz}
+' >> ../engrad.dat.$ibead
+


### PR DESCRIPTION
This interface allows to run LZSH simulations with the OMx methods in the MNDO package. Tested for OM2, OM3, ODM2 and ODM3. Works only for states with the same multiplicity, ISC cannot be described. Contributions Michal Belina and Jan Polena.