### PR TITLE
Langevin thermostats are incompatible with SHAKE

### DIFF
--- a/src/init.F90
+++ b/src/init.F90
@@ -682,6 +682,14 @@ contains
             write (*, *) 'Set imasst=1 and nmolt, natmolt and nshakemol accordingly.'
             error = 1
          end if
+         if (nshake /= 0 .and. (inose == 2 .or. inose == 4)) then
+            write (*, *) 'SHAKE is not compatible with GLE thermostat!'
+            error = 1
+         end if
+         if (nshake /= 0 .and. inose == 3) then
+            write (*, *) 'SHAKE is currently not compatible with Langeving thermostat!'
+            error = 1
+         end if
          if ((natmm + natqm /= natom)) then
             write (*, *) 'Natmm+natqm /= natom!'
             error = 1


### PR DESCRIPTION
Langevin and Generalized Langeving thermostats implemented in ABIN are implemented in a so called "massive" way where each atom is thermostatted separately. This makes them incompatible with SHAKE, since the thermostat breaks the SHAKE constrained. In the future, we could implement global Langevin thermostat. I don't think GLE can be implemented in a global way (but I might be wrong).

SHAKE is currently only possible with the global Nosé-Hoover thermostat (note that by default NHC thermostat is also massive).

```
&nhc
inose=1
imasst=0
/
```