### PR TITLE
GHA: Update Ubuntu version to 20.04

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [11, 12]
+         gcc_v: [9, 11, 12]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -fno-inline -fcheck=all -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -fno-early-inlining -fcheck=all -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -39,7 +39,9 @@ jobs:
 
     - name: Install GCC-7
       if: matrix.gcc_v == 7
-      run: sudo apt install gcc-7 gfortran-7 g++-7
+      run: |
+        sudo apt install gcc-7 gfortran-7 g++-7
+        echo "ABIN_FFLAGS=${ABIN_FFLAGS/-fprofile-abs-path/}" >> $GITHUB_ENV
 
     - name: Set GFortran version
       run: |
@@ -293,7 +295,9 @@ jobs:
 
     - name: Install GCC-7
       if: matrix.gcc_v == 7
-      run: sudo apt install gcc-7 gfortran-7 g++-7
+      run: |
+        sudo apt install gcc-7 gfortran-7 g++-7
+        echo "ABIN_FFLAGS=${ABIN_FFLAGS/-fprofile-abs-path/}" >> $GITHUB_ENV
 
     - name: Set GFortran version
       run: |

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -213,11 +213,6 @@ jobs:
   # Here we just take the defaults everywhere, except turning on FFTW
   # To use FFTW with other Gfortran versions, we would need to build it.
   fftw_build:
-    # NOTE: I tried using `ubuntu-20.04` instead of `ubuntu-18.04`.
-    # https://github.com/actions/virtual-environments#available-environments
-    # However, some tests started to fail, with small numerical differences ~1E-15.
-    # Not sure why, since default gfortran on 20.04 is 9.3.0, i.e. the same as we already
-    # test above. I tested this with both -O0 and -O2. 
     runs-on: ubuntu-20.04
     name: FFTW build
     needs: basic_build

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.gcc_v != 7
       run: |
         echo "ABIN_FFLAGS=${ABIN_FFLAGS} -fcheck=all -fsanitize=address,undefined,leak" >> $GITHUB_ENV
-        echo "ABIN_LDFLAGS=${ABIN_LDFLAGS} -fsanitize=address,undefined,leak" >> $GITHUB_ENV
+        echo "ABIN_LDLIBS=${ABIN_LDLIBS} -fsanitize=address,undefined,leak" >> $GITHUB_ENV
 
     - name: Set GFortran version
       run: |

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -finstrument-functions -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
   # These are the defaults used in Codecov, see:
@@ -67,7 +67,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make unittest
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
@@ -76,13 +76,14 @@ jobs:
         flags: unittests
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make e2etest
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
+        gcov: true
 
   intel_build:
     name: Intel OneAPI build

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -218,7 +218,7 @@ jobs:
   # Here we just take the defaults everywhere, except installing libfftw via apt
   # To use FFTW with other Gfortran versions, we would need to build it.
   fftw_build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: FFTW build
     needs: basic_build
     env:
@@ -236,7 +236,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/pfunit/build/installed
-        key: ${{ runner.os }}-ubuntu20.04-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-ubuntu22.04-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -245,7 +245,7 @@ jobs:
     - name: Build ABIN
       run: ./configure --pfunit ${HOME}/pfunit/build/installed/ --fftw && make
       env:
-        FFLAGS: ${{ env.ABIN_FFLAGS }} -Og
+        FFLAGS: ${{ env.ABIN_FFLAGS }}
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -260,6 +260,7 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         flags: unittests
+        gcov: true
 
     - name: Run End-to-End tests
       run: make e2etest
@@ -433,19 +434,21 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make unittest
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         flags: unittests
+        gcov: true
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make e2etest
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
+        gcov: true

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -229,7 +229,7 @@ jobs:
         fetch-depth: 2
 
     - name: Install FFTW libraries
-      run: sudo apt-get install libfftw3-dev gcov
+      run: sudo apt-get install libfftw3-dev
 
     - name: pFUnit build Cache
       id: pfunit-cache

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -83,6 +83,7 @@ jobs:
         gcov: true
 
     - name: Run End-to-End tests
+      if: always()
       run: make e2etest
 
     - name: Codecov upload

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -245,7 +245,7 @@ jobs:
     - name: Build ABIN
       run: ./configure --pfunit ${HOME}/pfunit/build/installed/ --fftw && make
       env:
-        FFLAGS: ${{ env.ABIN_FFLAGS }}
+        FFLAGS: ${{ env.ABIN_FFLAGS }} -Og
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -52,7 +52,7 @@ jobs:
     # pFUnit library is used to build and run unit tests
     - name: pFUnit build Cache
       id: pfunit-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/pfunit/build/installed
         # To force a pFUnit rebuild (bust the cache), make a change to install_pfunit.sh
@@ -145,7 +145,7 @@ jobs:
 
     - name: TCBP build cache
       id: tcpb-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/tcpb-cpp/lib
         # To force a rebuild (bust the cache), make a change to install_tcpb.sh
@@ -198,7 +198,7 @@ jobs:
 
     - name: pFUnit build Cache
       id: pfunit-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/pfunit/build/installed
         key: ${{ runner.os }}-ubuntu22.04-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
@@ -238,7 +238,7 @@ jobs:
 
     - name: pFUnit build Cache
       id: pfunit-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/pfunit/build/installed
         key: ${{ runner.os }}-ubuntu20.04-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
@@ -306,7 +306,7 @@ jobs:
         --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
     - name: MPICH build Cache
       id: mpich-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/mpich/${{ env.MPICH_V }}/install
         key: ${{runner.os}}-ubuntu20.04-mpich${{ env.MPICH_V }}-gfortran${{ env.GCC_V }}-${{hashFiles('dev_scripts/install_mpich.sh')}}
@@ -359,7 +359,7 @@ jobs:
         fetch-depth: 2
     - name: OpenMPI build cache
       id: openmpi-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/openmpi/${{ env.OPENMPI_V }}/install
         key: ${{runner.os}}-ubuntu20.04-openmpi${{ env.OPENMPI_V }}-gfortran-default-${{hashFiles('dev_scripts/install_openmpi.sh')}}
@@ -403,7 +403,7 @@ jobs:
         fetch-depth: 2
     - name: Plumed build cache
       id: plumed-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/plumed/${{ env.PLUMED_V }}/install
         key: ${{runner.os}}-ubuntu20.04-plumed${{env.PLUMED_V}}-gcc-default-${{hashFiles('dev_scripts/install_plumed.sh')}}
@@ -414,7 +414,7 @@ jobs:
 
     - name: pFUnit build Cache
       id: pfunit-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/pfunit/build/installed
         key: ${{ runner.os }}-ubuntu20.04-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -fcheck=all -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -66,7 +66,6 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         flags: unittests
-        gcov: false
 
     - name: Run End-to-End tests
       run: make e2etest && cd src/ && gcov *.o
@@ -76,8 +75,6 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        verbose: true
-        gcov: false 
 
   intel_build:
     name: Intel OneAPI build
@@ -163,7 +160,6 @@ jobs:
         name: tcpb
         fail_ci_if_error: true
         verbose: true
-        gcov: false
 
 
   optimized_build:
@@ -249,24 +245,22 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest
+      run: make unittest && cd src/ && gcov *.o
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         flags: unittests
-        gcov: true
 
     - name: Run End-to-End tests
-      run: make e2etest
+      run: make e2etest && cd src/ && gcov *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        gcov: true
         verbose: true
 
   mpich_build:
@@ -366,13 +360,12 @@ jobs:
         FFLAGS: ${{ env.ABIN_FFLAGS }}
         LDLIBS: ${{ env.ABIN_LDLIBS }}
     - name: test ABIN
-      run: make test
+      run: make test && cd src/ && gcov *.o
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        gcov: true
 
   plumed_build:
     name: PLUMED build
@@ -426,22 +419,20 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest
+      run: make unittest && cd src/ && gcov *.o
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         flags: unittests
-        gcov: true
 
     - name: Run End-to-End tests
-      run: make e2etest
+      run: make e2etest && cd src/ && gcov *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        gcov: true
         verbose: true

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -16,7 +16,7 @@ env:
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
   # These are the defaults used in Codecov, see:
   # https://github.com/codecov/uploader/blob/main/src/helpers/gcov.ts
-  GCOV_ARGS: -pb
+  GCOV_ARGS: ""
 
 jobs:
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -15,11 +15,11 @@ jobs:
 
   basic_build:
     name: Basic build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [7, 9, 10]
+         gcc_v: [9, 10, 11]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -119,8 +119,6 @@ jobs:
 
   tcpb_build:
     name: TCPB build
-    # NOTE: tcpb-cpp fails to build on Ubuntu 18.04,
-    # probably because of old libprotobuf library?
     runs-on: ubuntu-20.04
     needs: basic_build
     env:
@@ -167,11 +165,11 @@ jobs:
 
   optimized_build:
     name: Optimized build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: basic_build
     strategy:
       matrix:
-         gcc_v: [7, 9, 10]
+         gcc_v: [8, 9, 10]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -215,16 +213,13 @@ jobs:
     # However, some tests started to fail, with small numerical differences ~1E-15.
     # Not sure why, since default gfortran on 20.04 is 9.3.0, i.e. the same as we already
     # test above. I tested this with both -O0 and -O2. 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: FFTW build
     needs: basic_build
     strategy:
       fail-fast: false
-      matrix:
-         gcc_v: [7]
     env:
-      GCC_V: ${{ matrix.gcc_v}}
-      CODECOV_NAME: ${{format('{0} GCC-{1}', github.job, matrix.gcc_v)}}
+      CODECOV_NAME: ${{format('{0}', github.job)}}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -238,7 +233,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/pfunit/build/installed
-        key: ${{ runner.os }}-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -272,13 +267,13 @@ jobs:
 
   mpich_build:
     name: MPICH build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     needs: basic_build
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [7, 10]
+         gcc_v: [9, 10]
          mpich_v: ["3.4.3", "4.0.2"]
     env:
       # To speed-up MPICH build
@@ -334,21 +329,15 @@ jobs:
 
   openmpi_build:
     name: OpenMPI build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 25
     needs: basic_build
     strategy:
       fail-fast: false
-      # Let's just test one GFortran version, we do not really
-      # use OpenMPI with ABIN, and we already test all GCC
-      # versions with MPICH.
-      matrix:
-         gcc_v: [7]
     env:
       # To speed-up OpenMPI build
       CFLAGS: -O0
-      GCC_V: ${{ matrix.gcc_v}}
-      CODECOV_NAME: ${{format('{0} GCC-{1} OpenMPI-4.0', github.job, matrix.gcc_v)}}
+      CODECOV_NAME: ${{format('{0} OpenMPI-4.0', github.job)}}
       OPENMPI_V: "4.1"
       OPENMPI_PATCH: "2"
 
@@ -356,16 +345,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
-    - name: Set GFortran version
-      run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
-        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V}
     - name: OpenMPI build cache
       id: openmpi-cache
       uses: actions/cache@v2
       with:
         path: ~/openmpi/${{ env.OPENMPI_V }}/install
-        key: ${{runner.os}}-openmpi${{ env.OPENMPI_V }}-gfortran${{ env.GCC_V }}-${{hashFiles('dev_scripts/install_openmpi.sh')}}
+        key: ${{runner.os}}-openmpi${{ env.OPENMPI_V }}-gfortran-default-${{hashFiles('dev_scripts/install_openmpi.sh')}}
 
     - name: Build and Install OpenMPI
       if: steps.openmpi-cache.outputs.cache-hit != 'true'
@@ -387,21 +372,19 @@ jobs:
 
   plumed_build:
     name: PLUMED build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: basic_build
     strategy:
       fail-fast: false
       matrix:
          plumed_v: [2.7.4, 2.8.0]
-         gcc_v: [7]
 
     env:
       PLUMED_V: ${{ matrix.plumed_v}}
-      GCC_V: ${{ matrix.gcc_v}}
       # Speeding up the Plumed build
       CFLAGS: -O0
       CXXLAGS: -O0
-      CODECOV_NAME: ${{format('{0} GCC-{1} PLUMED-{2}', github.job, matrix.gcc_v, matrix.plumed_v)}}
+      CODECOV_NAME: ${{format('{0} PLUMED-{2}', github.job, matrix.plumed_v)}}
 
     steps:
     - uses: actions/checkout@v2
@@ -412,7 +395,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/plumed/${{ env.PLUMED_V }}/install
-        key: ${{runner.os}}-plumed${{env.PLUMED_V}}-gcc${{ env.GCC_V }}-${{hashFiles('dev_scripts/install_plumed.sh')}}
+        key: ${{runner.os}}-plumed${{env.PLUMED_V}}-gcc-default-${{hashFiles('dev_scripts/install_plumed.sh')}}
 
     - name: Build and Install PLUMED
       if: steps.plumed-cache.outputs.cache-hit != 'true'
@@ -423,7 +406,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/pfunit/build/installed
-        key: ${{ runner.os }}-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -163,13 +163,14 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make e2etest
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: tcpb
         fail_ci_if_error: true
+        gcov: true
 
 
   optimized_build:
@@ -333,12 +334,13 @@ jobs:
         FFLAGS: ${{ env.ABIN_FFLAGS }} -g
         LDLIBS: ${{ env.ABIN_LDLIBS }}
     - name: test ABIN
-      run: make test && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make test
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
+        gcov: true
 
   openmpi_build:
     name: OpenMPI build
@@ -375,12 +377,13 @@ jobs:
         FFLAGS: ${{ env.ABIN_FFLAGS }}
         LDLIBS: ${{ env.ABIN_LDLIBS }}
     - name: test ABIN
-      run: make test && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make test
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
+        gcov: true
 
   plumed_build:
     name: PLUMED build

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -38,6 +38,7 @@ jobs:
         fetch-depth: 2
 
     - name: Install GCC-7
+      if: matrix.gcc_v == 7
       run: sudo apt install gcc-7 gfortran-7 g++-7
 
     - name: Set GFortran version

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -276,7 +276,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [9, 10]
+         gcc_v: [7, 10]
          mpich_v: ["3.4.3", "4.0.2"]
     env:
       # To speed-up MPICH build
@@ -289,6 +289,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
+
+    - name: Install GCC-7
+      if: matrix.gcc_v == 7
+      run: sudo apt install gcc-7 gfortran-7 g++-7
+
     - name: Set GFortran version
       run: |
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -1,5 +1,9 @@
 name: GFortran CI
 
+# WARNING: When updating the OS version of the Github Actions runner,
+# e.g. from Ubuntu 20.04 to 22.04, you need to manually update the cache keys!
+# This is because there's no easy way to get the OS version from within this workflow file.
+
 on:
   push:
     branches: [ master ]
@@ -42,7 +46,7 @@ jobs:
       with:
         path: ~/pfunit/build/installed
         # To force a pFUnit rebuild (bust the cache), make a change to install_pfunit.sh
-        key: ${{ runner.os }}-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-ubuntu20.04-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -123,8 +127,7 @@ jobs:
     needs: basic_build
     env:
       FC: gfortran
-      GCC_V: 9
-      CODECOV_NAME: ${{format('{0} GCC9', github.job)}}
+      CODECOV_NAME: ${{format('{0}', github.job)}}
     steps:
     - uses: actions/checkout@v2
       with:
@@ -139,7 +142,7 @@ jobs:
       with:
         path: ~/tcpb-cpp/lib
         # To force a rebuild (bust the cache), make a change to install_tcpb.sh
-        key: ${{ runner.os }}-tcpb-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_tcpb.sh') }}
+        key: ${{ runner.os }}-ubuntu20.04-tcpb-gfortran-default-${{ hashFiles('dev_scripts/install_tcpb.sh') }}
 
     - name: Download and build tcpb_cpp
       if: steps.tcpb-cache.outputs.cache-hit != 'true'
@@ -193,7 +196,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/pfunit/build/installed
-        key: ${{ runner.os }}-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-ubuntu22.04-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -233,7 +236,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/pfunit/build/installed
-        key: ${{ runner.os }}-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-ubuntu20.04-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -296,7 +299,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/mpich/${{ env.MPICH_V }}/install
-        key: ${{runner.os}}-mpich${{ env.MPICH_V }}-gfortran${{ env.GCC_V }}-${{hashFiles('dev_scripts/install_mpich.sh')}}
+        key: ${{runner.os}}-ubuntu20.04-mpich${{ env.MPICH_V }}-gfortran${{ env.GCC_V }}-${{hashFiles('dev_scripts/install_mpich.sh')}}
 
     - name: Build and Install MPICH
       if: steps.mpich-cache.outputs.cache-hit != 'true'
@@ -350,7 +353,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/openmpi/${{ env.OPENMPI_V }}/install
-        key: ${{runner.os}}-openmpi${{ env.OPENMPI_V }}-gfortran-default-${{hashFiles('dev_scripts/install_openmpi.sh')}}
+        key: ${{runner.os}}-ubuntu20.04-openmpi${{ env.OPENMPI_V }}-gfortran-default-${{hashFiles('dev_scripts/install_openmpi.sh')}}
 
     - name: Build and Install OpenMPI
       if: steps.openmpi-cache.outputs.cache-hit != 'true'
@@ -395,7 +398,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/plumed/${{ env.PLUMED_V }}/install
-        key: ${{runner.os}}-plumed${{env.PLUMED_V}}-gcc-default-${{hashFiles('dev_scripts/install_plumed.sh')}}
+        key: ${{runner.os}}-ubuntu20.04-plumed${{env.PLUMED_V}}-gcc-default-${{hashFiles('dev_scripts/install_plumed.sh')}}
 
     - name: Build and Install PLUMED
       if: steps.plumed-cache.outputs.cache-hit != 'true'
@@ -406,7 +409,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/pfunit/build/installed
-        key: ${{ runner.os }}-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
+        key: ${{ runner.os }}-ubuntu20.04-pfunit-gfortran-default-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 
     - name: Download and build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -35,7 +35,7 @@ jobs:
         fetch-depth: 2
 
     - name: Install GCC-7
-      run: sudo apt install gcc-7
+      run: sudo apt install gcc-7 gfortran-7
 
     - name: Set GFortran version
       run: |

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -380,7 +380,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         plumed_v: [2.7.4, 2.8.0]
+         plumed_v: [2.7.6, 2.8.2]
 
     env:
       PLUMED_V: ${{ matrix.plumed_v}}

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -fno-early-inlining -fcheck=all -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -45,7 +45,7 @@ jobs:
       if: matrix.gcc_v != 7
       run: |
         echo "ABIN_FFLAGS=${ABIN_FFLAGS} -fcheck=all -fsanitize=address,undefined,leak" >> $GITHUB_ENV
-        echo "ABIN_LDFLAGS=${ABIN_LDFLAGS -fsanitize=address,undefined,leak" >> $GITHUB_ENV
+        echo "ABIN_LDFLAGS=${ABIN_LDFLAGS} -fsanitize=address,undefined,leak" >> $GITHUB_ENV
 
     - name: Set GFortran version
       run: |

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -76,6 +76,7 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         flags: unittests
+        gcov: true
 
     - name: Run End-to-End tests
       run: make e2etest

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -14,9 +14,6 @@ env:
   ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -finstrument-functions -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
-  # These are the defaults used in Codecov, see:
-  # https://github.com/codecov/uploader/blob/main/src/helpers/gcov.ts
-  GCOV_ARGS: ""
 
 jobs:
 
@@ -177,8 +174,6 @@ jobs:
     name: Optimized build
     # NOTE: We use a more recent Ubuntu version here
     # so we can test more recent GCC versions.
-    # NOTE: Because the cache key does not take into account OS version,
-    # we cannot test same GCC versions as in the basic build.
     runs-on: ubuntu-22.04
     needs: basic_build
     strategy:
@@ -323,12 +318,12 @@ jobs:
       # MPICH 4.0 also needs FCFLAGS set.
       # We also need to set it for ABIN compilation below.
       run: |
-        if [ $GCC_V -eq 10 ];then export FFLAGS="-fallow-argument-mismatch";export FCFLAGS="-fallow-argument-mismatch";fi && \
+        if [ $GCC_V -ge 10 ];then export FFLAGS="-fallow-argument-mismatch";export FCFLAGS="-fallow-argument-mismatch";fi && \
         ./dev_scripts/install_mpich.sh ${HOME}/mpich ${MPICH_V}
 
     - name: build ABIN
       run: |
-        if [ $GCC_V -eq 10 ];then export FFLAGS="-fallow-argument-mismatch $FFLAGS";fi && \
+        if [ $GCC_V -ge 10 ];then export FFLAGS="-fallow-argument-mismatch $FFLAGS";fi && \
         ./configure --mpi ${HOME}/mpich/${MPICH_V}/install && make
       env:
         FFLAGS: ${{ env.ABIN_FFLAGS }} -g

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -59,7 +59,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov *.o
+      run: make unittest && cd src/ && gcov -uba *.o
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
@@ -68,7 +68,7 @@ jobs:
         flags: unittests
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov *.o
+      run: make e2etest && cd src/ && gcov -uba *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -165,11 +165,16 @@ jobs:
 
   optimized_build:
     name: Optimized build
+    # NOTE: We use a more recent Ubuntu version here
+    # so we can test more recent GCC versions.
+    # NOTE: Because the cache key does not take into account OS version,
+    # we cannot test same GCC versions as in the basic build.
     runs-on: ubuntu-22.04
     needs: basic_build
     strategy:
+      fail-fast: false
       matrix:
-         gcc_v: [10, 11, 12]
+         gcc_v: [11, 12]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -384,7 +389,7 @@ jobs:
       # Speeding up the Plumed build
       CFLAGS: -O0
       CXXLAGS: -O0
-      CODECOV_NAME: ${{format('{0} PLUMED-{2}', github.job, matrix.plumed_v)}}
+      CODECOV_NAME: ${{format('{0} PLUMED-{1}', github.job, matrix.plumed_v)}}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -g -Og -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 
@@ -39,6 +39,13 @@ jobs:
       run: |
         sudo apt install gcc-7 gfortran-7 g++-7
         echo "ABIN_FFLAGS=${ABIN_FFLAGS/-fprofile-abs-path/}" >> $GITHUB_ENV
+
+    - name: Enable runtime checks
+      # It looks like this messes up the code coverage, so enabling only some builds
+      if: matrix.gcc_v != 7
+      run: |
+        echo "ABIN_FFLAGS=${ABIN_FFLAGS} -fcheck=all -fsanitize=address,undefined,leak" >> $GITHUB_ENV
+        echo "ABIN_LDFLAGS=${ABIN_LDFLAGS -fsanitize=address,undefined,leak" >> $GITHUB_ENV
 
     - name: Set GFortran version
       run: |

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -245,7 +245,7 @@ jobs:
     - name: Build ABIN
       run: ./configure --pfunit ${HOME}/pfunit/build/installed/ --fftw && make
       env:
-        FFLAGS: ${{ env.ABIN_FFLAGS }}
+        FFLAGS: ${{ env.ABIN_FFLAGS }} -fcheck=all,no-mem,no-pointer
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -229,7 +229,7 @@ jobs:
         fetch-depth: 2
 
     - name: Install FFTW libraries
-      run: sudo apt-get install libfftw3-dev
+      run: sudo apt-get install libfftw3-dev gcov
 
     - name: pFUnit build Cache
       id: pfunit-cache
@@ -267,6 +267,7 @@ jobs:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
         gcov: true
+        verbose: true
 
   mpich_build:
     name: MPICH build
@@ -443,3 +444,4 @@ jobs:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
         gcov: true
+        verbose: true

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -14,6 +14,9 @@ env:
   ABIN_FFLAGS: -O0 -fopenmp --coverage -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
+  # These are the defaults used in Codecov, see:
+  # https://github.com/codecov/uploader/blob/main/src/helpers/gcov.ts
+  GCOV_ARGS: -pb
 
 jobs:
 
@@ -63,7 +66,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov -uba *.o
+      run: make unittest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
@@ -72,7 +75,7 @@ jobs:
         flags: unittests
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov -uba *.o
+      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
@@ -155,7 +158,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov *.o
+      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
@@ -247,7 +250,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov *.o
+      run: make unittest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
@@ -256,7 +259,7 @@ jobs:
         flags: unittests
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov *.o
+      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
@@ -318,7 +321,7 @@ jobs:
         FFLAGS: ${{ env.ABIN_FFLAGS }} -g
         LDLIBS: ${{ env.ABIN_LDLIBS }}
     - name: test ABIN
-      run: make test && cd src/ && gcov *.o
+      run: make test && cd src/ && gcov ${GCOV_ARGS} *.o
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
@@ -360,7 +363,7 @@ jobs:
         FFLAGS: ${{ env.ABIN_FFLAGS }}
         LDLIBS: ${{ env.ABIN_LDLIBS }}
     - name: test ABIN
-      run: make test && cd src/ && gcov *.o
+      run: make test && cd src/ && gcov ${GCOV_ARGS} *.o
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
@@ -419,7 +422,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov *.o
+      run: make unittest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
@@ -428,7 +431,7 @@ jobs:
         flags: unittests
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov *.o
+      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -finstrument-functions -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -219,14 +219,12 @@ jobs:
     - name: Run End-to-End tests
       run: make e2etest
 
-  # Here we just take the defaults everywhere, except turning on FFTW
+  # Here we just take the defaults everywhere, except installing libfftw via apt
   # To use FFTW with other Gfortran versions, we would need to build it.
   fftw_build:
     runs-on: ubuntu-20.04
     name: FFTW build
     needs: basic_build
-    strategy:
-      fail-fast: false
     env:
       CODECOV_NAME: ${{format('{0}', github.job)}}
     steps:
@@ -255,7 +253,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
-      run: make unittest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make unittest
 
     - name: Codecov upload unit tests
       uses: codecov/codecov-action@v3
@@ -264,13 +262,14 @@ jobs:
         flags: unittests
 
     - name: Run End-to-End tests
-      run: make e2etest && cd src/ && gcov ${GCOV_ARGS} *.o
+      run: make e2etest
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
+        gcov: true
 
   mpich_build:
     name: MPICH build

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -30,7 +30,7 @@ jobs:
       CODECOV_NAME: ${{format('{0} GCC-{1}', github.job, matrix.gcc_v)}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Set GFortran version
@@ -95,7 +95,7 @@ jobs:
       # intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
@@ -129,7 +129,7 @@ jobs:
       FC: gfortran
       CODECOV_NAME: ${{format('{0}', github.job)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
@@ -183,7 +183,7 @@ jobs:
       GCC_V: ${{ matrix.gcc_v}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Set GFortran version
@@ -224,7 +224,7 @@ jobs:
     env:
       CODECOV_NAME: ${{format('{0}', github.job)}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
@@ -286,7 +286,7 @@ jobs:
       CODECOV_NAME: ${{format('{0} GCC-{1} MPICH-{2}', github.job, matrix.gcc_v, matrix.mpich_v)}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Set GFortran version
@@ -345,7 +345,7 @@ jobs:
       OPENMPI_PATCH: "2"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: OpenMPI build cache
@@ -390,7 +390,7 @@ jobs:
       CODECOV_NAME: ${{format('{0} PLUMED-{1}', github.job, matrix.plumed_v)}}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
     - name: Plumed build cache

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -88,7 +88,6 @@ jobs:
         intel-oneapi-compiler-fortran
         intel-oneapi-mpi
         intel-oneapi-mpi-devel
-
       # intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     steps:
@@ -159,7 +158,6 @@ jobs:
       with:
         name: tcpb
         fail_ci_if_error: true
-        verbose: true
 
 
   optimized_build:
@@ -261,7 +259,6 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        verbose: true
 
   mpich_build:
     name: MPICH build
@@ -323,7 +320,6 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        gcov: false
 
   openmpi_build:
     name: OpenMPI build
@@ -435,4 +431,3 @@ jobs:
       with:
         name: ${{env.CODECOV_NAME}}
         fail_ci_if_error: true
-        verbose: true

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [9, 10, 11]
+         gcc_v: [9, 10]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -165,11 +165,11 @@ jobs:
 
   optimized_build:
     name: Optimized build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: basic_build
     strategy:
       matrix:
-         gcc_v: [8, 9, 10]
+         gcc_v: [10, 11, 12]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -fcheck=all -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -fno-inline -fcheck=all -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   # FFLAGS for building ABIN, applicable for most jobs
-  ABIN_FFLAGS: -O0 -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
+  ABIN_FFLAGS: -g -Og -fopenmp --coverage -fprofile-abs-path -ffpe-trap=invalid,zero,overflow,denormal -fimplicit-none -Wall -Wno-integer-division -Wno-maybe-uninitialized
   ABIN_LDLIBS: --coverage
   OPTIMIZED_FFLAGS: -O3 -fopenmp -fimplicit-none -Wall -Wno-integer-division
 
@@ -245,7 +245,7 @@ jobs:
     - name: Build ABIN
       run: ./configure --pfunit ${HOME}/pfunit/build/installed/ --fftw && make
       env:
-        FFLAGS: ${{ env.ABIN_FFLAGS }} -fcheck=all,no-mem,no-pointer
+        FFLAGS: ${{ env.ABIN_FFLAGS }}
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [9, 10]
+         gcc_v: [7, 9, 10]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -33,6 +33,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
+
+    - name: Install GCC-7
+      run: sudo apt install gcc-7
+
     - name: Set GFortran version
       run: |
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -38,7 +38,7 @@ jobs:
         fetch-depth: 2
 
     - name: Install GCC-7
-      run: sudo apt install gcc-7 gfortran-7
+      run: sudo apt install gcc-7 gfortran-7 g++-7
 
     - name: Set GFortran version
       run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -46,9 +46,14 @@ comment:
   require_changes: no
 
 ignore:
-  - "docs"
-  - "sample_inputs"
-  - "interfaces"
-  - "utils"
-  - "dev_scripts"
+  - "docs/*"
+  - "tests/*"
+  - "sample_inputs/*"
+  - "interfaces/*"
+  - "utils/*"
+  - "dev_scripts/*"
+  - "*.md"
   - "**/*.md"
+
+fixes:
+  - "::src/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -46,14 +46,9 @@ comment:
   require_changes: no
 
 ignore:
-  - "docs/*"
-  - "tests/*"
-  - "sample_inputs/*"
-  - "interfaces/*"
-  - "utils/*"
-  - "dev_scripts/*"
-  - "*.md"
+  - "docs"
+  - "tests"
+  - "sample_inputs"
+  - "utils"
+  - "dev_scripts"
   - "**/*.md"
-
-fixes:
-  - "::src/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,3 +37,6 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
+
+ignore:
+  - "utils"

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,8 +30,8 @@ parsers:
     branch_detection:
       conditional: yes
       loop: yes
-      method: yes
-      macro: yes
+      method: no
+      macro: no
 
 comment:
   layout: "reach,diff,flags,tree"

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,8 +30,8 @@ parsers:
     branch_detection:
       conditional: yes
       loop: yes
-      method: no
-      macro: no
+      method: yes
+      macro: yes
 
 comment:
   layout: "reach,diff,flags,tree"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,7 +5,7 @@ codecov:
     # are completed, otherwise we'll temporarily receive
     # incomplete coverage reports.
     # Note that unit test coverage builds count towards the build count!
-    after_n_builds: 16
+    after_n_builds: 18
     wait_for_ci: yes
 
 coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,13 +4,7 @@ codecov:
     # Send report to Github PR only after all CIs
     # are completed, otherwise we'll temporarily receive
     # incomplete coverage reports.
-    # Right now, the following builds are collecting coverage data:
-    # Basic Builds - (2)
-    # OpenMPI Build
-    # mpich builds (4)
-    # FFTW Build
-    # Intel Build
-    # Plumed Builds (2 total)
+    # Note that unit test coverage builds count towards the build count!
     after_n_builds: 16
     wait_for_ci: yes
 
@@ -29,8 +23,7 @@ coverage:
           - unittests
     patch:
       default:
-        target: auto
-        threshold: 10%
+        target: 80%
 
 parsers:
   gcov:
@@ -44,11 +37,3 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: no
-
-ignore:
-  - "docs"
-  - "tests"
-  - "sample_inputs"
-  - "utils"
-  - "dev_scripts"
-  - "**/*.md"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,13 +5,13 @@ codecov:
     # are completed, otherwise we'll temporarily receive
     # incomplete coverage reports.
     # Right now, the following builds are collecting coverage data:
-    # Basic Builds - (Gfortran versions 7, 8, 9)
+    # Basic Builds - (2)
     # OpenMPI Build
     # mpich builds (4)
     # FFTW Build
     # Intel Build
     # Plumed Builds (2 total)
-    after_n_builds: 18
+    after_n_builds: 16
     wait_for_ci: yes
 
 coverage:

--- a/src/force_mm.F90
+++ b/src/force_mm.F90
@@ -91,7 +91,6 @@ contains
          attypes(itype) = normalize_atom_name(atom_types(i))
          itype = itype + 1
       end do
-      deallocate (attypes)
    end function normalize_atom_types
 
    ! Here we create the mapping from atom index

--- a/src/force_mm.F90
+++ b/src/force_mm.F90
@@ -53,6 +53,7 @@ contains
       call flush (stdout)
       call flush (stderr)
       write (stdout, '(A)') ''
+      deallocate (normalized_atom_types)
    end subroutine initialize_mm
 
    subroutine finalize_mm()
@@ -90,6 +91,7 @@ contains
          attypes(itype) = normalize_atom_name(atom_types(i))
          itype = itype + 1
       end do
+      deallocate (attypes)
    end function normalize_atom_types
 
    ! Here we create the mapping from atom index

--- a/src/nosehoover.F90
+++ b/src/nosehoover.F90
@@ -108,6 +108,13 @@ contains
 
       error = .false.
 
+      call int_nonnegative(inose, 'inose')
+      call int_positive(nchain, 'nchain')
+      call int_positive(nrespnose, 'nrespnose')
+      call int_positive(nmolt, 'nmolt')
+      call int_switch(imasst, 'imasst')
+      call real_nonnegative(temp, 'temp')
+
       if (nchain > maxchain) then
          write (stderr, '(A)') 'Maximum number of Nose-Hoover chains exceeded'
          error = .true.
@@ -131,9 +138,17 @@ contains
          error = .true.
       end if
 
+      if (temp * AUTOK < 1 .and. inose > 0) then
+         write (stderr, '(A)') 'Temperature below 1 Kelvin. Are you sure?'
+         write (stderr, '(A)') chknow
+         if (iknow /= 1) error = .true.
+      end if
+
       if (nmolt > natom) then
          write (stdout, '(A)') 'nmolt > natom, which is not possible. Consult the manual.'
-         error = .true.
+         ! We need to exit early here, otherwise we risk out-of-bounds arrays access below
+         call fatal_error(__FILE__, __LINE__, &
+            & 'Invalid NHC thermostat parameter(s)')
       end if
 
       if (imasst == 0) then
@@ -156,19 +171,6 @@ contains
             if (iknow /= 1) error = .true.
          end if
       end if
-
-      if (temp * AUTOK < 1 .and. inose > 0) then
-         write (stderr, '(A)') 'Temperature below 1 Kelvin. Are you sure?'
-         write (stderr, '(A)') chknow
-         if (iknow /= 1) error = .true.
-      end if
-
-      call int_nonnegative(inose, 'inose')
-      call int_positive(nchain, 'nchain')
-      call int_positive(nrespnose, 'nrespnose')
-      call int_positive(nmolt, 'nmolt')
-      call int_switch(imasst, 'imasst')
-      call real_nonnegative(temp, 'temp')
 
       if (error) then
          call fatal_error(__FILE__, __LINE__, &

--- a/tests/INIT/test.sh
+++ b/tests/INIT/test.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-rm -f ERROR abin.out movie.xyz restart.xyz *dat
+rm -f ERROR ABIN_ERROR? abin.out movie.xyz restart.xyz *dat
 if [[ $1 = "clean" ]];then
   exit 0
 fi

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -129,7 +129,7 @@ test : clean_plumed_output clean_terapi_output clean_gle_output
 	./gle
 	./nhc
 	./pot
-	./mm
+	#./mm
 	./spline
 	./io
 	./interface

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -129,7 +129,7 @@ test : clean_plumed_output clean_terapi_output clean_gle_output
 	./gle
 	./nhc
 	./pot
-	#./mm
+	./mm
 	#./spline
 	./io
 	./interface

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -130,7 +130,7 @@ test : clean_plumed_output clean_terapi_output clean_gle_output
 	./nhc
 	./pot
 	#./mm
-	./spline
+	#./spline
 	./io
 	./interface
 

--- a/unit_tests/Makefile
+++ b/unit_tests/Makefile
@@ -130,7 +130,7 @@ test : clean_plumed_output clean_terapi_output clean_gle_output
 	./nhc
 	./pot
 	./mm
-	#./spline
+	./spline
 	./io
 	./interface
 

--- a/unit_tests/test_mm.pf
+++ b/unit_tests/test_mm.pf
@@ -61,6 +61,7 @@ contains
    end subroutine
 
    @test
+   @disable
    subroutine test_like_charges()
       types = (/'Kr', 'Xe'/)
       names = types
@@ -97,6 +98,7 @@ contains
       @assertLessThan(fz(1, 1), 0.0D0, 'fz repel')
    end subroutine
 
+   @disable
    subroutine test_opposite_charges()
       types = (/'Kr', 'Xe'/)
       names = types
@@ -124,6 +126,7 @@ contains
    end subroutine
 
    @test
+   @disable
    subroutine test_LJ_minimum()
       real(DP), dimension(NATOM, NWALK) :: fzero = 0.0D0
       real(DP) :: E_min
@@ -152,6 +155,7 @@ contains
    end subroutine
 
    @test
+   @disable
    subroutine test_bead_scaling()
       integer, parameter :: NTYPES = 2
       real(DP), dimension(NATOM, NWALK) :: fx1, fy1, fz1

--- a/unit_tests/test_mm.pf
+++ b/unit_tests/test_mm.pf
@@ -61,7 +61,6 @@ contains
    end subroutine
 
    @test
-   @disable
    subroutine test_like_charges()
       types = (/'Kr', 'Xe'/)
       names = types
@@ -98,7 +97,6 @@ contains
       @assertLessThan(fz(1, 1), 0.0D0, 'fz repel')
    end subroutine
 
-   @disable
    subroutine test_opposite_charges()
       types = (/'Kr', 'Xe'/)
       names = types
@@ -126,7 +124,6 @@ contains
    end subroutine
 
    @test
-   @disable
    subroutine test_LJ_minimum()
       real(DP), dimension(NATOM, NWALK) :: fzero = 0.0D0
       real(DP) :: E_min
@@ -155,7 +152,6 @@ contains
    end subroutine
 
    @test
-   @disable
    subroutine test_bead_scaling()
       integer, parameter :: NTYPES = 2
       real(DP), dimension(NATOM, NWALK) :: fx1, fy1, fz1
@@ -208,8 +204,6 @@ contains
    end subroutine
 
    ! Helper function if you want to check the potential
-   @test
-   @disable
    subroutine print_lj_potential()
       integer, parameter :: NATOM = 2, NWALK = 1
       real(DP) :: r0, rmax, r, dr
@@ -248,8 +242,6 @@ contains
       close (u)
    end subroutine
 
-   @test
-   @disable
    subroutine print_coulomb_potential()
       integer, parameter :: NATOM = 2, NWALK = 1
       real(DP) :: r0, rmax, r, dr

--- a/unit_tests/test_spline.pf
+++ b/unit_tests/test_spline.pf
@@ -117,8 +117,8 @@ contains
 
    ! TODO: This needs to throw before the FP exception
    ! For some reason, missing y-value does not trip the read statement. :-(
-   @test
-   @disable
+   !@test
+   !@disable
    subroutine test_validate_grid_values()
       integer :: u
 


### PR DESCRIPTION
Github actions removed the runner for Ubuntu 18.04, which is why ABIN CI tests were not running. Here I update all jobs to Ubuntu 20.04. 

~~This unfortunately means we can no longer test with gfortran-7.
@JanosJiri for your PRs, please always manually test on Argon or Neon with GCC 7.3.~~

EDIT: I figured out how to install GCC-7 so we're good here.