### PR TITLE
Use usleep to wait for TeraChem

### DIFF
--- a/src/fortran_interfaces.F90
+++ b/src/fortran_interfaces.F90
@@ -55,6 +55,7 @@ module mod_interfaces
       !   integer(C_INT), intent(in) :: natom, walkmax, watpot
       !end subroutine
 
+      ! https://cyber.dabamos.de/programming/modernfortran/sleep.html
       ! int usleep(useconds_t useconds)
       function usleep(useconds) bind(c, name='usleep')
          import :: c_int, c_int32_t

--- a/src/fortran_interfaces.F90
+++ b/src/fortran_interfaces.F90
@@ -4,6 +4,7 @@
 ! Some functions are currently outside of modules due to
 ! circular dependencies.
 module mod_interfaces
+   use, intrinsic :: iso_c_binding, only: c_int, c_int32_t
    use mod_const, only: DP
    public
    interface
@@ -53,6 +54,13 @@ module mod_interfaces
       !   real(C_DOUBLE), intent(inout) :: eclas
       !   integer(C_INT), intent(in) :: natom, walkmax, watpot
       !end subroutine
+
+      ! int usleep(useconds_t useconds)
+      function usleep(useconds) bind(c, name='usleep')
+         import :: c_int, c_int32_t
+         integer(kind=c_int32_t), value :: useconds
+         integer(kind=c_int) :: usleep
+      end function usleep
 
    end interface
 

--- a/src/init.F90
+++ b/src/init.F90
@@ -128,7 +128,7 @@ contains
          isbc, rb_sbc, kb_sbc, gamm, gammthr, conatom, mpi_milisleep, narchive, xyz_units, &
          dime, ncalc, idebug, enmini, rho, iknow, watpot, iremd, iplumed, plumedfile, &
          en_restraint, en_diff, en_kk, restrain_pot, &
-         pot_ref, nstep_ref, nteraservers, max_wait_time, cp2k_mpi_beads
+         pot_ref, nstep_ref, nteraservers, max_mpi_wait_time, cp2k_mpi_beads
 
       namelist /remd/ nswap, nreplica, deltaT, Tmax, temp_list
 

--- a/src/init.F90
+++ b/src/init.F90
@@ -125,7 +125,7 @@ contains
       ! in this subroutine must ensure that the namelists can be in any order.
       namelist /general/ pot, ipimd, mdtype, istage, inormalmodes, nwalk, nstep, icv, ihess, imini, nproc, iqmmm, &
          nwrite, nwritex, nwritev, nwritef, dt, irandom, nabin, irest, nrest, anal_ext, &
-         isbc, rb_sbc, kb_sbc, gamm, gammthr, conatom, mpi_sleep, narchive, xyz_units, &
+         isbc, rb_sbc, kb_sbc, gamm, gammthr, conatom, mpi_milisleep, narchive, xyz_units, &
          dime, ncalc, idebug, enmini, rho, iknow, watpot, iremd, iplumed, plumedfile, &
          en_restraint, en_diff, en_kk, restrain_pot, &
          pot_ref, nstep_ref, nteraservers, max_wait_time, cp2k_mpi_beads

--- a/src/utils.F90
+++ b/src/utils.F90
@@ -346,4 +346,20 @@ contains
       end if
    end subroutine int_switch
 
+   subroutine milisleep(milisec)
+      use, intrinsic :: iso_c_binding, only: c_int, c_int32_t
+      use mod_interfaces, only: usleep
+      integer :: milisec
+      integer(kind=c_int32_t) :: usec
+      integer(kind=c_int) :: c_err
+
+      usec = int(milisec * 1000, c_int32_t)
+      ! TODO: Based on usleep(2) manpage, we probably should not sleep more than a second
+      c_err = usleep(usec)
+      if (c_err /= 0) then
+         write (stderr, *) "usleep returned an error: ", c_err
+         call fatal_error(__FILE__, __LINE__, "usleep failed!")
+      end if
+   end subroutine milisleep
+
 end module mod_utils

--- a/tests/TERAPI-FAILS/input.in.valid
+++ b/tests/TERAPI-FAILS/input.in.valid
@@ -1,5 +1,5 @@
 &general
-mpi_sleep=-1
+mpi_milisleep=-1
 
 pot='_tera_'
 watpot=1

--- a/tests/TERAPI-FAILS/input.in1
+++ b/tests/TERAPI-FAILS/input.in1
@@ -1,5 +1,5 @@
 &general
-mpi_sleep=-1
+mpi_milisleep=-1
 
 pot='_tera_'
 watpot=1

--- a/tests/TERAPI-FAILS/input.in2
+++ b/tests/TERAPI-FAILS/input.in2
@@ -2,7 +2,7 @@ Intentionally invalid ABIN input
 (requires PIMD without thermostat)
 
 &general
-mpi_sleep=-1
+mpi_milisleep=-1
 
 pot='_tera_'
 ipimd=1,

--- a/tests/TERAPI-FAILS/input.in4
+++ b/tests/TERAPI-FAILS/input.in4
@@ -1,5 +1,5 @@
 &general
-mpi_sleep=-1
+mpi_milisleep=-1
 
 pot='_tera_'
 watpot=1

--- a/tests/TERAPI-FAILS/input.in5
+++ b/tests/TERAPI-FAILS/input.in5
@@ -1,5 +1,5 @@
 &general
-max_wait_time=0.5
+max_mpi_wait_time=0.5
 
 pot='_tera_'
 ipimd=0,

--- a/tests/TERAPI-FAILS/input.in6
+++ b/tests/TERAPI-FAILS/input.in6
@@ -1,5 +1,5 @@
 &general
-max_wait_time=0.5
+max_mpi_wait_time=0.5
 
 pot='_tera_'
 ipimd=0,

--- a/tests/TERAPI-FAILS/input.in7
+++ b/tests/TERAPI-FAILS/input.in7
@@ -1,5 +1,5 @@
 &general
-mpi_sleep=-1
+mpi_milisleep=-1
 
 pot='_tera_'
 watpot=1

--- a/tests/TERAPI-FAILS/input.in8
+++ b/tests/TERAPI-FAILS/input.in8
@@ -1,5 +1,5 @@
 &general
-mpi_sleep=-1
+mpi_milisleep=-1
 
 pot='_tera_'
 watpot=1


### PR DESCRIPTION
When communicating with TeraChem via MPI, we're sleeping for 50 miliseconds. Otherwise, ABIN busy-waits and consumes the whole CPU.

Here is a better implementation of this behaviour, using the system call function `usleep`, instead of calling to shell. 
Closes #163 