### PR TITLE
Cleanup create_trajectories.sh with shellcheck

### DIFF
--- a/utils/create_trajectories.sh
+++ b/utils/create_trajectories.sh
@@ -200,12 +200,22 @@ done
 # Submit jobs
 k=1
 if [[ -n "${submit_command-}" ]];then
-   cd $folder || exit 1
-   while [[ $k -le $j ]]
-   do
-      if [[ -f $folder.$isample.$k.sh ]];then
-         $submit_command $folder.$isample.$k.sh
-      fi
-      (( k++ ))
-   done
+    cd $folder || exit 1
+    if [[ $submit_command = "bash" ]];then
+        echo "Launching $j calculations locally"
+        submit_command="nohup $submit_command"
+    else
+        echo "Submitting $j calculations with: $submit_command"
+    fi
+    while [[ $k -le $j ]]
+    do
+        if [[ -f $folder.$isample.$k.sh ]];then
+            $submit_command $folder.$isample.$k.sh &
+        fi
+        (( k++ ))
+    done
+    # Wait for submit commands to finish (they should be fast!)
+    if [[ $submit_command != "bash" ]]; then
+        wait
+    fi
 fi

--- a/utils/create_trajectories.sh
+++ b/utils/create_trajectories.sh
@@ -32,7 +32,8 @@ folder=MY_MOLECULE_TRAJS
 # Directory with the input files for ABIN (input.in et al)
 inputdir=TEMPLATE-$folder
 
-# File with ABIN input parameters
+# File with ABIN input parameters, we need this path
+# so we can inject random number seed into it.
 abin_input=$inputdir/input.in
 
 # Random seed to generate random seeds for individual trajectories
@@ -175,17 +176,13 @@ EOF
       grep -v -e '/bin/bash' -e "INPUTPARAM=" -e "INPUTGEOM=" -e "INPUTVELOC=" $launch_script >> $folder/TRAJ.$i/r.$folder.$i
    else
       if [[ -n ${veloc-} ]]; then
-         echo "$abin_exe -i input.in -x initial.xyz -v veloc.in > abin.out 2>&1"
+         echo "$abin_exe -i input.in -x initial.xyz -v veloc.in > abin.out 2>&1" > $folder/TRAJ.$i/r.$folder.$i
       else
-         echo "$abin_exe -i input.in -x initial.xyz > abin.out 2>&1"
+         echo "$abin_exe -i input.in -x initial.xyz > abin.out 2>&1" > $folder/TRAJ.$i/r.$folder.$i
       fi
    fi
 
-   chmod 755 $folder/TRAJ.$i/r.$folder.$i
-
-   echo "cd TRAJ.$i || exit" >> $folder/$folder.$isample.$j.sh
-   echo "./r.$folder.$i" >> $folder/$folder.$isample.$j.sh
-   echo "cd $PWD/$folder || exit" >> $folder/$folder.$isample.$j.sh
+   echo "(cd TRAJ.$i && bash r.$folder.$i)" >> $folder/$folder.$isample.$j.sh
 
    # Distribute calculations evenly between jobs for queue
    if [[ $remainder -le 0 ]];then

--- a/utils/create_trajectories.sh
+++ b/utils/create_trajectories.sh
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------------
 # create_trajectories.sh - Generate and execute a set ABIN simulations
 #
-# Initial geometries (and optionally velocities) are taken sequentially from XYZ movie files.
+# Initial geometries (and optionally velocities) are taken sequentially from a XYZ trajectory file.
 
 # The trajectories are executed and stored in $folder.
 
@@ -15,30 +15,48 @@
 # Exit if undefined variable is used
 set -u
 
-#######-----SETUP---#############
-irandom0=156863189  # random seed, set negative for random seed based on time
-movie=coords.xyz    # PATH TO a XYZ movie with initial geometries
-veloc=vels.xyz      # PATH to XYZ initial velocities (optional)
-isample=1	    # initial number of traj
-nsample=100	    # number of trajectories
-folder=MP2-NH4      # Name of the folder with trajectories
-inputdir=TEMPLATE-$folder   # Directory with input files for ABIN
-abin_input=$inputdir/input.in   # main input file for ABIN
-launch_script=$inputdir/r.abin	# this is the file that is submitted by qsub
+#### SETUP ####
+# Path to a XYZ file with initial geometries
+movie=coords.xyz
+# Path to XYZ file with initial velocities (optional)
+# veloc=vels.xyz
+
+# Starting index for the initial geometries
+isample=1
+# End index
+nsample=100
+
+# Folder name where the trajectories will be created
+folder=MY_MOLECULE_TRAJS
+
+# Directory with the input files for ABIN (input.in et al)
+inputdir=TEMPLATE-$folder
+
+# File with ABIN input parameters
+abin_input=$inputdir/input.in
+
+# Random seed to generate random seeds for individual trajectories
+# Set to a negative number for a time-based random seed.
+irandom0=156863189
+
+# Specify path to launch script that is normally submitted to the queuing system.
+# Comment out this line if you're running locally.
+launch_script=$inputdir/r.abin
 
 # Comment out this line if you don't want to run calculations yet
 # submit_command="qsub -cwd -V -q nq -cwd "
 # If you don't use queing system (like SLURM), use the following line
 # submit_command=bash
 
-# Number of batch jobs to submit, set only if you have more trajectories than jobs
+# Number of batch jobs to submit to queue
+# set only if you have more trajectories than jobs
 # jobs=20
 ########## END OF SETUP ##########
 
 
 function files_exist {
   for f in "$@";do
-    if [[ ! -f $f ]];then
+    if [[ -n ${f-} && ! -f $f ]]; then
       echo "ERROR: File '$f' does not exist!"
       exit 1
     fi
@@ -47,7 +65,7 @@ function files_exist {
 
 function folders_exist {
   for d in "$@";do
-    if [[ ! -d $d ]];then
+    if [[ -n ${f-} && ! -d $d ]]; then
       echo "ERROR: Directory '$d' does not exist!"
       exit 1
     fi
@@ -55,10 +73,7 @@ function folders_exist {
 }
 
 folders_exist "$inputdir"
-files_exist "$movie" "$abin_input" "$launch_script"
-if [[ -n "$veloc" ]];then
-  files_exist "$veloc"
-fi
+files_exist "$movie" "${veloc-}" "$abin_input" "${launch_script-}"
 
 natom=$(head -1 $movie)
 if [[ $natom -lt 1 ]];then
@@ -97,11 +112,11 @@ j=1
 i=$isample
 w=0 #current number of simulations in current j-th job
 
-#--------------------generation of random numbers--------------------------------
+# Generate random number generator seeds for individual trajectories
 echo "Generating $nsample random integers for random seeds"
 echo "abin-randomint --seed $irandom0 --num $nsample > iran.dat"
-abin-randomint --seed $irandom0 --num $nsample > iran.dat
-if [[ $? -ne "0" ]];then
+if ! abin-randomint --seed $irandom0 --num $nsample > iran.dat
+then
   echo "ERROR: Could not generate random numbers"
   exit 1
 fi
@@ -134,7 +149,7 @@ while [[ $i -le "$nsample" ]];do
    # Prepare input geometry and velocities
    head -$offset $movie | tail -$natom2 > initial.xyz
    if [[ -n "${veloc-}" ]];then
-      head -$offset $veloc | tail -$natom2 > $folder/TRAJ.$i/veloc.in
+      head -$offset "$veloc" | tail -$natom2 > $folder/TRAJ.$i/veloc.in
    fi
 
    ## Now prepare input.in and r.abin
@@ -155,10 +170,11 @@ EOF
       echo "INPUTVELOC=veloc.in" >> $folder/TRAJ.$i/r.$folder.$i
    fi
 
-   grep -v -e '/bin/bash' -e "JOBNAME=" -e "INPUTPARAM=" -e "INPUTGEOM=" -e "INPUTVELOC=" $launch_script >> $folder/TRAJ.$i/r.$folder.$i
+   if [[ -n ${launch_script-} ]];then
+      grep -v -e '/bin/bash' -e "JOBNAME=" -e "INPUTPARAM=" -e "INPUTGEOM=" -e "INPUTVELOC=" $launch_script >> $folder/TRAJ.$i/r.$folder.$i
+   fi
 
    chmod 755 $folder/TRAJ.$i/r.$folder.$i
-
 
    echo "cd TRAJ.$i || exit" >> $folder/$folder.$isample.$j.sh
    echo "./r.$folder.$i" >> $folder/$folder.$isample.$j.sh

--- a/utils/create_trajectories.sh
+++ b/utils/create_trajectories.sh
@@ -42,6 +42,9 @@ irandom0=156863189
 # Specify path to launch script that is normally submitted to the queuing system.
 # Comment out this line if you're running locally.
 launch_script=$inputdir/r.abin
+# If you don't provide a launch script,
+# we need a (preferably absolute) path to abin executable
+# abin_exe=/path/to/abin
 
 # Comment out this line if you don't want to run calculations yet
 # submit_command="qsub -cwd -V -q nq -cwd "
@@ -160,10 +163,8 @@ while [[ $i -le "$nsample" ]];do
 
    cat > $folder/TRAJ.$i/r.$folder.$i << EOF
 #!/bin/bash
-JOBNAME=ABIN.$folder.${i}_$$_\${JOB_ID}
 INPUTPARAM=input.in
 INPUTGEOM=initial.xyz
-OUTPUT=abin.out
 EOF
 
    if [[ -n ${veloc-} ]];then
@@ -171,7 +172,13 @@ EOF
    fi
 
    if [[ -n ${launch_script-} ]];then
-      grep -v -e '/bin/bash' -e "JOBNAME=" -e "INPUTPARAM=" -e "INPUTGEOM=" -e "INPUTVELOC=" $launch_script >> $folder/TRAJ.$i/r.$folder.$i
+      grep -v -e '/bin/bash' -e "INPUTPARAM=" -e "INPUTGEOM=" -e "INPUTVELOC=" $launch_script >> $folder/TRAJ.$i/r.$folder.$i
+   else
+      if [[ -n ${veloc-} ]]; then
+         echo "$abin_exe -x -i input.in initial.xyz -v veloc.in > abin.out 2>&1"
+      else
+         echo "$abin_exe -x -i input.in initial.xyz > abin.out 2>&1"
+      fi
    fi
 
    chmod 755 $folder/TRAJ.$i/r.$folder.$i

--- a/utils/create_trajectories.sh
+++ b/utils/create_trajectories.sh
@@ -150,7 +150,7 @@ while [[ $i -le "$nsample" ]];do
    cp -r $inputdir/* $folder/TRAJ.$i
 
    # Prepare input geometry and velocities
-   head -$offset $movie | tail -$natom2 > initial.xyz
+   head -$offset $movie | tail -$natom2 > $folder/TRAJ.$i/initial.xyz
    if [[ -n "${veloc-}" ]];then
       head -$offset "$veloc" | tail -$natom2 > $folder/TRAJ.$i/veloc.in
    fi
@@ -175,9 +175,9 @@ EOF
       grep -v -e '/bin/bash' -e "INPUTPARAM=" -e "INPUTGEOM=" -e "INPUTVELOC=" $launch_script >> $folder/TRAJ.$i/r.$folder.$i
    else
       if [[ -n ${veloc-} ]]; then
-         echo "$abin_exe -x -i input.in initial.xyz -v veloc.in > abin.out 2>&1"
+         echo "$abin_exe -i input.in -x initial.xyz -v veloc.in > abin.out 2>&1"
       else
-         echo "$abin_exe -x -i input.in initial.xyz > abin.out 2>&1"
+         echo "$abin_exe -i input.in -x initial.xyz > abin.out 2>&1"
       fi
    fi
 


### PR DESCRIPTION
Mostly cosmetic changes and cleanup.

One functional change: It is now possible to specify `submit_command=bash` if the trajectories are to be run directly on a machine (e.g. Squirrel or Hamilton nodes) instead of submitting to queing system. In this case, the launch script `r.abin` doesn't need to be provided in the template directory.