### PR TITLE
Add 'ignore_state' in Launda-Zener hopping

### DIFF
--- a/src/abin.F90
+++ b/src/abin.F90
@@ -25,7 +25,7 @@ program abin
       & nwrite, nstep, it, inormalmodes, istage, irest, STOP_SIMULATION
    use mod_init, only: init
    use mod_sh, only: surfacehop, sh_init, get_nacm, move_vars
-   use mod_lz, only: lz_hop, en_array_lz, lz_rewind, nsinglet_lz, ntriplet_lz
+   use mod_lz, only: lz_hop, en_array_lz, lz_rewind
    use mod_kinetic, only: temperature
    use mod_utils, only: del_file, archive_file
    use mod_transform, only: initialize_pi_transforms, &
@@ -67,12 +67,6 @@ program abin
 
    write (stdout, '(A)') 'Job started at: '//trim(get_formatted_date_and_time(time_start))
    write (stdout, *) ''
-
-   ! LZ warning for too many states
-   if (ipimd == 5 .and. (nsinglet_lz > 2 .or. ntriplet_lz > 2)) then
-      write (*, *) 'WARNING: LZ was derived for a two-state problem. More states might cause unphysical behavior.'
-      write (stdout, *) ''
-   end if
 
    ! Transform coordinates and velocities for Path Integral MD
    ! (staging or normal modes)

--- a/src/force_abin.F90
+++ b/src/force_abin.F90
@@ -68,31 +68,6 @@ contains
       close (u)
    end subroutine write_sh_data
 
-   subroutine write_lz_data(nstate, nsinglet, ntriplet, tocalc)
-      integer, intent(in) :: nstate
-      integer, intent(in) :: nsinglet, ntriplet
-      integer, dimension(:), intent(in) :: tocalc
-      integer :: ist
-      integer :: u
-
-      if (nstate /= nsinglet + ntriplet) then
-         call fatal_error(__FILE__, __LINE__, &
-            & 'LZ: nstate /= nsinglet + ntriplet')
-      end if
-
-      open (newunit=u, file='state.dat')
-      write (u, '(I0)') nstate
-
-      ! Print for which state we need gradient
-      ! First we have singlets, then triplets
-      do ist = 1, nstate
-         if (tocalc(ist) == 1) write (u, '(I0)') ist
-      end do
-      write (u, '(I0)') nsinglet
-      write (u, '(I0)') ntriplet
-      close (u)
-   end subroutine write_lz_data
-
    function get_shellscript(potential) result(shellscript)
       use mod_utils, only: toupper
       character(len=*), intent(in) :: potential
@@ -231,7 +206,7 @@ contains
       use mod_system, only: names
       use mod_sh_integ, only: nstate
       use mod_sh, only: tocalc, en_array, istate
-      use mod_lz, only: nstate_lz, tocalc_lz, en_array_lz, istate_lz, nsinglet_lz, ntriplet_lz
+      use mod_lz, only: nstate_lz, tocalc_lz, en_array_lz, istate_lz, write_lz_data
       use mod_qmmm, only: natqm
       use mod_utils, only: toupper, append_rank
       implicit none
@@ -276,7 +251,7 @@ contains
 
             ! Landau-Zener
             if (ipimd == 5) then
-               call write_lz_data(nstate_lz, nsinglet_lz, ntriplet_lz, tocalc_lz)
+               call write_lz_data()
             end if
 
             ! Call the external program

--- a/src/init.F90
+++ b/src/init.F90
@@ -142,7 +142,7 @@ contains
          k, r0, kx, ky, kz, r0_morse, d0_morse, k_morse, D0_dw, lambda_dw, k_dw, r0_dw, &
          Nshake, ishake1, ishake2, shake_tol, potential_file
 
-      namelist /lz/ initstate_lz, nstate_lz, nsinglet_lz, ntriplet_lz, deltaE_lz, energydifthr_lz
+      namelist /lz/ initstate_lz, nstate_lz, nsinglet_lz, ntriplet_lz, ignore_state, deltaE_lz, energydifthr_lz
 
       namelist /qmmm/ natqm, natmm, q, LJ_rmin, LJ_eps, mm_types
 

--- a/src/init.F90
+++ b/src/init.F90
@@ -43,7 +43,7 @@ contains
       use mod_potentials_sh
       use mod_sh_integ, only: phase, nstate
       use mod_sh, only: read_sh_input, print_sh_input
-      use mod_lz
+      use mod_lz, only: read_lz_input, print_lz_input, lz_init
       use mod_qmmm, only: natqm, natmm
       use mod_force_mm, only: initialize_mm
       use mod_force_h2o, only: initialize_h2o_pot, h2opot
@@ -120,7 +120,6 @@ contains
       ! - remd:    parameters for Replica Exchange MD
       ! - sh:      parameters for Surface Hopping, moved to mod_sh module
       ! - system:  system-specific parameters for model potentials, masses, SHAKE constraints...
-      ! - lz:      parameters for Landau-Zener excited state dynamics.
       ! - qmmm:    parameters for internal QMMM (not really tested).
       !
       ! All namelists need to be in a single input file, and the code
@@ -141,8 +140,6 @@ contains
          nang, ang1, ang2, ang3, ndih, dih1, dih2, dih3, dih4, shiftdihed, &
          k, r0, kx, ky, kz, r0_morse, d0_morse, k_morse, D0_dw, lambda_dw, k_dw, r0_dw, &
          Nshake, ishake1, ishake2, shake_tol, potential_file
-
-      namelist /lz/ initstate_lz, nstate_lz, nsinglet_lz, ntriplet_lz, ignore_state, deltaE_lz, energydifthr_lz
 
       namelist /qmmm/ natqm, natmm, q, LJ_rmin, LJ_eps, mm_types
 
@@ -370,9 +367,8 @@ contains
       end if
 
       if (ipimd == 5) then
-         read (uinput, lz)
-         rewind (uinput)
-         call lz_init(pot) !Init arrays for possible restart
+         call read_lz_input(uinput)
+         call lz_init(pot)
       end if
 
       if (iremd == 1) then
@@ -630,10 +626,6 @@ contains
             write (*, *) 'Invalid ipimd value'
             error = 1
          end if
-         if (ipimd == 5 .and. pot == '_tera_' .and. ntriplet_lz > 0) then
-            write (*, *) 'ERROR: Landau-Zener with Singlet-Triplet transitions not implemented with TeraChem over MPI.'
-            error = 1
-         end if
          if (ipimd == 5 .and. nwalk /= 1) then
             write (*, *) 'ERROR: LZ not implemented with multiple walkers.'
             error = 1
@@ -794,7 +786,7 @@ contains
             write (stdout, *)
          end if
          if (ipimd == 5) then
-            write (stdout, nml=lz, delim='APOSTROPHE')
+            call print_lz_input()
             write (stdout, *)
          end if
          if (iqmmm > 0 .or. pot == '_mm_') then

--- a/src/landau_zener.F90
+++ b/src/landau_zener.F90
@@ -15,7 +15,7 @@ module mod_lz
    use mod_files, only: stdout, stderr
    ! TODO: Break coupling between LZ and SH modules
    ! The following are needed for TERA-MPI interface
-   use mod_sh, only: set_current_state, inac
+   use mod_sh, only: set_current_state, inac, ignore_state
    use mod_sh_integ, only: nstate
    implicit none
    private
@@ -177,7 +177,8 @@ contains
 
       do ist1 = ibeg, iend
          if (ist1 == ist) cycle
-         ! only closest states are considered for hopping
+         if (ist1 == ignore_state) cycle
+         ! only closest upper and lower states are considered for hopping
          if (ist1 > (ist + 1) .or. ist1 < (ist - 1)) cycle
 
          do ihist = 1, 4

--- a/src/surfacehop.F90
+++ b/src/surfacehop.F90
@@ -93,7 +93,7 @@ module mod_sh
    ! Useful e.g. for ethylene 2-state SA3 dynamics
    ! This is a bit of an ugly hack, it would be more general to have an array
    ! of states that are calculated but ignored.
-   integer, public, protected :: ignore_state = 0
+   integer :: ignore_state = 0
 
    namelist /sh/ istate_init, nstate, substep, deltae, integ, inac, nohop, phase, decoh_alpha, popthr, ignore_state, &
       nac_accu1, nac_accu2, popsumthr, energydifthr, energydriftthr, adjmom, revmom, &
@@ -254,6 +254,10 @@ contains
       if (ignore_state == istate_init) then
          write (stderr, '(A)') 'ERROR: ignore_state == istate_init'
          write (stderr, '(A)') 'I cannot start on an ignored state'
+         error = .true.
+      end if
+      if (ignore_state > nstate) then
+         write (stderr, '(A)') 'Ignored state > number of computed states.'
          error = .true.
       end if
 

--- a/src/surfacehop.F90
+++ b/src/surfacehop.F90
@@ -89,8 +89,11 @@ module mod_sh
    integer, allocatable :: tocalc(:, :)
    ! Current electronic state
    integer, public, protected :: istate
-   ! for ethylene 2-state SA3 dynamics
-   integer :: ignore_state = 0
+   ! Do not consider hopping into this state
+   ! Useful e.g. for ethylene 2-state SA3 dynamics
+   ! This is a bit of an ugly hack, it would be more general to have an array
+   ! of states that are calculated but ignored.
+   integer, public, protected :: ignore_state = 0
 
    namelist /sh/ istate_init, nstate, substep, deltae, integ, inac, nohop, phase, decoh_alpha, popthr, ignore_state, &
       nac_accu1, nac_accu2, popsumthr, energydifthr, energydriftthr, adjmom, revmom, &
@@ -118,7 +121,7 @@ contains
       ! TODO: Write a print_sh_header()
       ! with all major parameters included and explained
       if (ignore_state /= 0) then
-         write (stdout, '(A,I0)') 'Ignoring state ', ignore_state
+         write (stdout, '(A,I0,A)') 'Ignoring state ', ignore_state, ' for hopping'
       end if
 
       ! Determining the initial state


### PR DESCRIPTION
Another small bug (or perhaps rather a missing feature) found by Jack Taylor. Sometimes we want to calculate more electronic state (e.g. to make CASSCF more stable) but do not want to consider them in hoping algorithms. A prototypical example is simulating ethylene with SA3-CAS(2,2) starting from S1 and wanting to prevent hops to S2.

Also a minor refactoring to make more LZ stuff private to the `mod_lz` module.