### PR TITLE
Update fortitude linter to v0.7

### DIFF
--- a/fortitude.toml
+++ b/fortitude.toml
@@ -1,12 +1,18 @@
 [check]
 ignore = [
-  "S001", # line-too-long
-  "S051", # deprecated-relational-operator (fix available)
-  "S101", # trailing-whitespace
-  "S102", # incorrect-space-before-comment, we should enable this, autofix enable
-  "M011", # use-all (should use "only:")
-  "M001", # procedure-not-in-module (need a per-file ignore for init.F90)
-  "T042", # assumed-size-character-intent TODO: We should fix all instances!
+  "line-too-long",
+  "trailing-whitespace", # we should enable this, autofix available 
+  "incorrect-space-before-comment", # we should enable this, autofix available 
+  "use-all", # should use "only:"
+  "assumed-size-character-intent", # TODO: We should fix all instances!
+  "implicit-external-procedures", # requires Fortran 2018
+]
+exclude = [
+  "src/fftw3.F90",
+  "src/force_cp2k.F90",
 ]
 line-length = 132
 show-fixes = true
+[check.per-file-ignores]
+"src/forces.F90" = ["procedure-not-in-module"]
+"src/random.F90" = ["deprecated-relational-operator"]

--- a/src/arrays.F90
+++ b/src/arrays.F90
@@ -3,6 +3,7 @@
 module mod_arrays
    use mod_const, only: DP
    implicit none
+   public
 
    ! TODO: Stop this madness, put everything into Traj_Data derived type
    ! and then create type(Traj_Data) :: trajectory. trajectory_prev

--- a/src/compile_info.F90
+++ b/src/compile_info.F90
@@ -2,6 +2,7 @@
 ! to get the current date and time,
 ! which are taken from preprocessor constants,
 ! and the current Git commit, which is passed in from Makefile.
+! allow(procedure-not-in-module) ! fortitude linter
 subroutine print_compile_info()
    use iso_fortran_env, only: compiler_version, compiler_options
    use mod_files, only: stdout

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -8,6 +8,7 @@
 ! ABIN uses atomic units internally
 module mod_const
    implicit none
+   public
    ! TODO; Separate DP to its own module, mod_kinds
    ! and rename mod_const to mod_phys_const
    integer, parameter :: DP = kind(1.0D0)

--- a/src/estimators.F90
+++ b/src/estimators.F90
@@ -3,6 +3,8 @@ module mod_estimators
    use mod_const, only: DP, AUtoFS
    use mod_files, only: UCV, UCVDCV, UESTENERGY
    implicit none
+   public
+   ! TODO: Make all of the *_cumul variables private
    real(DP) :: est_prim_cumul = 0.0D0, est_vir_cumul = 0.0D0
    real(DP) :: est_prim2_cumul = 0.0D0, est_prim_vir = 0.0D0, est_vir2_cumul = 0.0D0
    real(DP) :: cv_prim_cumul = 0.0D0, cv_vir_cumul = 0.0D0, cv_dcv_cumul = 0.0D0

--- a/src/fftw_interface.F90
+++ b/src/fftw_interface.F90
@@ -4,8 +4,8 @@ module mod_fftw3
    use, intrinsic :: iso_c_binding
 #ifndef USE_FFTW
    use mod_error, only: not_compiled_with
-   implicit none
 #endif
+   implicit none
    private
    public :: fftw_normalmodes_init, fftw_normalmodes_finalize
    public :: dft_normalmode2cart, dft_cart2normalmode

--- a/src/files.F90
+++ b/src/files.F90
@@ -68,7 +68,7 @@ contains
 
    subroutine files_init(isbc, phase, ndist, nang, ndih)
       use mod_general, only: ipimd, irest, iremd, pot, &
-                           & icv, ihess, idebug, nwritev, nwritef, en_restraint
+                           & icv, ihess, nwritev, nwritef, en_restraint
       use mod_mpi, only: get_mpi_rank
       integer, intent(in) :: isbc, phase, ndist, nang, ndih
       character(len=10) :: chaccess

--- a/src/forces.F90
+++ b/src/forces.F90
@@ -141,6 +141,7 @@ subroutine force_wrapper(x, y, z, fx, fy, fz, e_pot, chpot, walkmax)
    use mod_force_tera, only: force_tera
    use mod_terampi_sh, only: force_terash
    implicit none
+   ! allow(external-procedure) ! fortitude linter
    external :: force_water
    real(DP), intent(in) :: x(:, :), y(:, :), z(:, :)
    real(DP), intent(inout) :: fx(:, :), fy(:, :), fz(:, :)

--- a/src/h2o_cvrqd.f
+++ b/src/h2o_cvrqd.f
@@ -369,7 +369,7 @@ C     SCALE AND SHIFT THE ZERO
       SUBROUTINE rel(V,R1,R2,THETA)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
       DIMENSION FT(82), cv(82)
-      integer :: nv, ZERO, i, i5, idx
+      integer :: nv, ZERO, i, i5
 
       data nv/82/
       DATA ZERO/0.0D0/
@@ -1389,7 +1389,7 @@ c     $      0.15860145369897d0,-1.6351695982132d0,1d0/
       data ifirst/0/
       if(ifirst.eq.0)then
        ifirst=1
-    1  format(/1x,'CVRQD PES for H2O molecule')
+c   1  format(/1x,'CVRQD PES for H2O molecule')
 c
 c     remove mass correction from vrest
 c
@@ -1398,8 +1398,8 @@ c
        xmd=3670.483031d0
        fact=1.d0/((1.d0/xmd)-(1.d0/xmh))
 c       write(6,65)
-   65  format(/1x,'parameters for delta v hdo ',
-     $       /1x,'    i    j    k')
+c  65  format(/1x,'parameters for delta v hdo ',
+c    $       /1x,'    i    j    k')
        do 60 i=1,9
 c        write(6,5)(idxm(i,j)-1,j=1,3),cmass(i)
         cmass(i)=cmass(i)*fact
@@ -1430,11 +1430,11 @@ c
 c     adjust parameters using scale factors
 c
 c       write(6,57)f5z,fbasis,fcore,frest
-   57  format(/1x,'adjusting parameters using scale factors ',
-     $        /1x,'f5z =    ',f11.8,
-     $        /1x,'fbasis = ',f11.8,
-     $        /1x,'fcore =  ',f11.8,
-     $        /1x,'frest =  ',f11.8)
+c  57  format(/1x,'adjusting parameters using scale factors ',
+c    $        /1x,'f5z =    ',f11.8,
+c    $        /1x,'fbasis = ',f11.8,
+c    $        /1x,'fcore =  ',f11.8,
+c    $        /1x,'frest =  ',f11.8)
        phh1=phh1*f5z
        deoh=deoh*f5z
        do 59 i=1,245
@@ -1443,18 +1443,18 @@ c       write(6,57)f5z,fbasis,fcore,frest
    59  continue
 c       write(6,55)phh1,phh2,deoh,alphaoh,roh
 c       write(6,58)reoh,thetae,b1,((idx(i,j)-1,j=1,3),c5z(i),i=1,245)
-   58  format(/1x,'three body parameters:',
-     $        /1x,'reoh = ',f10.4,' thetae = ',f10.4,
-     $        /1x,'betaoh = ',f10.4,
-     $        /1x,'    i    j    k   cijk',
-     $        /(1x,3i5,1pe15.7))
+c  58  format(/1x,'three body parameters:',
+c    $        /1x,'reoh = ',f10.4,' thetae = ',f10.4,
+c    $        /1x,'betaoh = ',f10.4,
+c    $        /1x,'    i    j    k   cijk',
+c    $        /(1x,3i5,1pe15.7))
        do 66 i=1,9
         cmass(i)=cmass(i)*frest
    66  continue
 c       write(6,76)((idxm(i,j),j=1,3),cmass(i),i=1,9)
-   76  format(/1x,'mass correction factors ',
-     $        /1x,'    i    j    k   cijk',
-     $        /(1x,3i5,1pe15.7))
+c  76  format(/1x,'mass correction factors ',
+c    $        /1x,'    i    j    k   cijk',
+c    $        /(1x,3i5,1pe15.7))
 c
 c     convert parameters from 1/cm, angstrom to a.u.
 c

--- a/src/init.F90
+++ b/src/init.F90
@@ -1206,6 +1206,7 @@ end module mod_init
 
 ! We cannot include finish in the module, since it would
 ! result in circular dependencies.
+! allow(procedure-not-in-module) ! fortitude linter
 subroutine finish(error_code)
    use mod_arrays, only: deallocate_arrays
    use mod_general, only: pot, pot_ref, ipimd, inormalmodes, en_restraint

--- a/src/modules.F90
+++ b/src/modules.F90
@@ -96,6 +96,7 @@ end module mod_system
 
 module mod_chars
    implicit none
+   public
    character(len=*), parameter :: CHKNOW = 'If you know what you are doing, &
     &set iknow=1 (namelist general) to proceed.'
 end module mod_chars

--- a/src/pbc.F90
+++ b/src/pbc.F90
@@ -4,6 +4,7 @@
 module PBC
    use mod_const, only: DP
    implicit none
+   private
    real(DP) :: boxx, boxy, boxz
    integer, allocatable :: natmol(:) ! used for wrapping, independent of nmolt
    integer :: nmol = 1 !used for wraping, independent of nmolt


### PR DESCRIPTION
A new version of fortitude linter has been released, with lot's more configuration options:

https://github.com/PlasmaFAIR/fortitude/releases/tag/v0.7.0

This will allow us to run it in CI, I'll add it in a follow-up PR.