### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -37,11 +37,12 @@ jobs:
 
   basic_build:
     name: Basic build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-         gcc_v: [9, 12]
+         os: [ubuntu-22.04]
+         gcc_v: [9, 15]
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v}}
@@ -52,15 +53,10 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Install libstdc++-dev
-      if: matrix.gcc_v == 9
-      run: sudo apt-get install libstdc++-9-dev
-
-    - name: Set GFortran version
-      run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
-        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
-        --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
+    - uses: fortran-lang/setup-fortran@v1
+      with:
+        compiler: gcc
+        version: ${{ matrix.gcc_v }}
 
     # pFUnit library is used to build and run unit tests
     - name: pFUnit build Cache

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -1,4 +1,4 @@
-name: GFortran CI
+name: build
 
 # WARNING: When updating the OS version of Github Actions runner,
 # e.g. from Ubuntu 20.04 to 22.04, you need to manually update the cache keys!
@@ -36,7 +36,7 @@ env:
 jobs:
 
   basic_build:
-    name: Basic build
+    name: gfortran
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -97,7 +97,7 @@ jobs:
         fail_ci_if_error: true
 
   debug_build:
-    name: Debug build
+    name: Debug
     runs-on: ubuntu-24.04
 
     steps:
@@ -119,7 +119,7 @@ jobs:
       run: make e2etest
 
   intel_build:
-    name: Intel build
+    name: Intel ifx
     runs-on: ubuntu-22.04
 
     steps:
@@ -140,7 +140,7 @@ jobs:
       run: make e2etest
 
   tcpb_build:
-    name: TCPB build
+    name: TCPB interface
     runs-on: ubuntu-22.04
     needs: basic_build
     env:
@@ -183,7 +183,7 @@ jobs:
 
 
   optimized_build:
-    name: Optimized build
+    name: Optimized
     runs-on: ubuntu-22.04
     needs: basic_build
     strategy:
@@ -229,7 +229,7 @@ jobs:
   # To use FFTW with other Gfortran versions, we would need to build it.
   fftw_build:
     runs-on: ubuntu-22.04
-    name: FFTW build
+    name: FFTW
     needs: basic_build
     env:
       CODECOV_NAME: ${{format('{0}', github.job)}}
@@ -277,7 +277,7 @@ jobs:
         fail_ci_if_error: true
 
   mpich_build:
-    name: MPICH build
+    name: MPICH
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     needs: basic_build
@@ -340,7 +340,7 @@ jobs:
         fail_ci_if_error: true
 
   openmpi_build:
-    name: OpenMPI build
+    name: OpenMPI
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     needs: basic_build
@@ -380,7 +380,7 @@ jobs:
         fail_ci_if_error: true
 
   plumed_build:
-    name: PLUMED build
+    name: PLUMED
     runs-on: ubuntu-22.04
     needs: basic_build
     strategy:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -205,7 +205,7 @@ fi
 echo "Running tests in directories:"
 echo ${folders[@]}
 
-global_error=0
+errors=0
 
 for dir in ${folders[@]}
 do
@@ -264,7 +264,7 @@ do
       if diff_files; then
         echo -e "\033[0;32mPASSED\033[0m"
       else
-        global_error=1
+        let errors++
         echo -e "$dir \033[0;31mFAILED\033[0m"
       fi
    fi
@@ -276,10 +276,9 @@ done
 
 echo " "
 
-if [[ ${global_error} -ne 0 ]];then
-   echo -e "Some tests \033[0;31mFAILED\033[0m."
+if [[ ${errors} -ne 0 ]];then
+   echo -e "$errors tests \033[0;31mFAILED\033[0m."
+   exit 1
 else
    echo -e "\033[0;32mAll tests PASSED.\033[0m"
 fi
-
-exit $global_error


### PR DESCRIPTION
Split from #219 since these updates are not MacOS-specific

- test with gfortran 15
- rename CI jobs
- print number of failed tests in `test.sh`