### PR TITLE
Bump pFUnit version

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -67,7 +67,7 @@ jobs:
       id: pfunit-cache
       uses: actions/cache@v5
       with:
-        path: ~/pfunit/build/installed
+        path: ~/pfunit/v*/pFUnit/build/installed/
         # To force a pFUnit rebuild (bust the cache), make a change to install_pfunit.sh
         key: ${{ runner.os }}-ubuntu22.04-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 

--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -67,7 +67,7 @@ jobs:
       id: pfunit-cache
       uses: actions/cache@v5
       with:
-        path: ~/pfunit/v*/pFUnit/build/installed/
+        path: ~/pfunit/build/installed/
         # To force a pFUnit rebuild (bust the cache), make a change to install_pfunit.sh
         key: ${{ runner.os }}-ubuntu22.04-pfunit-gfortran${{ env.GCC_V }}-${{ hashFiles('dev_scripts/install_pfunit.sh') }}
 

--- a/dev_scripts/install_mpich.sh
+++ b/dev_scripts/install_mpich.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 MPICH_DIR="${1-$HOME/mpich}"
 # We take current stable version as default
 # (as of 06 Nov 2020).
-MPICH_VERSION="${2-"3.3.2"}"
+MPICH_VERSION="${2-"4.0.2"}"
 
 TAR_FILE="mpich-${MPICH_VERSION}.tar.gz"
 DOWNLOAD_URL="https://www.mpich.org/static/downloads/${MPICH_VERSION}/${TAR_FILE}"
@@ -21,25 +21,25 @@ INSTALL_DIR="$MPICH_DIR/$MPICH_VERSION/install"
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
 NCPUS=2
 
-if [[ -d $INSTALL_DIR ]];then
+if [[ -d "$INSTALL_DIR" ]];then
   echo "Found existing MPICH installation in $INSTALL_DIR"
   echo "Remove this folder if you want to reinstall"
   exit 1
 fi
 
-if [[ ! -d $MPICH_DIR/$MPICH_VERSION/pkg ]];then
-  mkdir -p $MPICH_DIR/$MPICH_VERSION/pkg
+if [[ ! -d "$MPICH_DIR/$MPICH_VERSION/pkg" ]];then
+  mkdir -p "$MPICH_DIR/$MPICH_VERSION/pkg"
 fi
 
-if [[ ! -f  $MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE} ]];then
-  curl "$DOWNLOAD_URL" > $MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE}
+if [[ ! -f "$MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE}" ]];then
+  curl "$DOWNLOAD_URL" > "$MPICH_DIR/$MPICH_VERSION/pkg/${TAR_FILE}"
 fi
 
-if [[ -d $MPICH_DIR/$MPICH_VERSION/src ]];then
-  rm -rf $MPICH_DIR/$MPICH_VERSION/src
+if [[ -d "$MPICH_DIR/$MPICH_VERSION/src" ]];then
+  rm -rf "$MPICH_DIR/$MPICH_VERSION/src"
 fi
-mkdir -p $MPICH_DIR/$MPICH_VERSION/src
-cd $MPICH_DIR/$MPICH_VERSION/src && tar -xzf ../pkg/${TAR_FILE} && cd mpich-${MPICH_VERSION}
+mkdir -p "$MPICH_DIR/$MPICH_VERSION/src"
+cd "$MPICH_DIR/$MPICH_VERSION/src" && tar -xzf "../pkg/${TAR_FILE}" && cd "mpich-${MPICH_VERSION}"
 
 # If you're building MPI for general use, not only for ABIN,
 # you might want change some of the configure options.
@@ -59,7 +59,7 @@ cd $MPICH_DIR/$MPICH_VERSION/src && tar -xzf ../pkg/${TAR_FILE} && cd mpich-${MP
   --with-pm=hydra --with-device=ch3:nemesis \
   --with-namepublisher=pmi \
   --enable-static --disable-shared \
-  --prefix=${INSTALL_DIR} 2>&1 |\
+  --prefix="${INSTALL_DIR}" 2>&1 |\
   tee configure.log
 make -j $NCPUS 2>&1 | tee make.log
 make install 2>&1 | tee make_install.log

--- a/dev_scripts/install_openmpi.sh
+++ b/dev_scripts/install_openmpi.sh
@@ -29,15 +29,15 @@ if [[ -d "$OPENMPI_DIR/$OPENMPI_VERSION" ]];then
   exit 1
 fi
 
-mkdir -p $OPENMPI_DIR/$OPENMPI_VERSION/src
-mkdir -p $OPENMPI_DIR/$OPENMPI_VERSION/pkg
+mkdir -p "$OPENMPI_DIR/$OPENMPI_VERSION/src"
+mkdir -p "$OPENMPI_DIR/$OPENMPI_VERSION/pkg"
 
-curl "${DOWNLOAD_URL}" > $OPENMPI_DIR/$OPENMPI_VERSION/pkg/${TAR_FILE}
-cd $OPENMPI_DIR/$OPENMPI_VERSION/src && tar -xzf ../pkg/${TAR_FILE} && \
-  cd openmpi-${OPENMPI_VERSION}.${OPENMPI_VERSION_PATCH}
+curl "${DOWNLOAD_URL}" > "$OPENMPI_DIR/$OPENMPI_VERSION/pkg/${TAR_FILE}"
+cd "$OPENMPI_DIR/$OPENMPI_VERSION/src" && tar -xzf "../pkg/${TAR_FILE}" && \
+  cd "openmpi-${OPENMPI_VERSION}.${OPENMPI_VERSION_PATCH}"
 
 # For compilation on PHOTOX clusters, add --with-sge
-./configure FC=gfortran CC=gcc CXX=g++ --with-gnu-ld --prefix=${INSTALL_DIR} 2>&1 |\
+./configure FC=gfortran CC=gcc CXX=g++ --with-gnu-ld --prefix="${INSTALL_DIR}" 2>&1 |\
   tee configure.log
 make -j ${NCPUS} all 2>&1 | tee make.log
 make install 2>&1 | tee make_install.log

--- a/dev_scripts/install_pfunit.sh
+++ b/dev_scripts/install_pfunit.sh
@@ -12,7 +12,7 @@ if [[ "$#" -ne 1 ]];then
 fi
 
 mkdir -p "$1"
-REPO_DIR="$1/$PFUNIT_VERSION/pFUnit"
+REPO_DIR="$1"
 
 git clone --recursive --branch $PFUNIT_VERSION https://github.com/Goddard-Fortran-Ecosystem/pFUnit "$REPO_DIR" && cd "$REPO_DIR"
 

--- a/dev_scripts/install_pfunit.sh
+++ b/dev_scripts/install_pfunit.sh
@@ -3,17 +3,18 @@
 # Exit script immediately upon error
 set -euo pipefail
 
-REPO_DIR="$HOME/pfunit"
-if [[ "$#" -eq 1 && ! -z $1 ]];then
-   REPO_DIR=$1
-fi
+# This must correspond to a git tag in https://github.com/Goddard-Fortran-Ecosystem/pFUnit/tags
+PFUNIT_VERSION="v4.18.0"
 
-if [[ -e $REPO_DIR ]];then
-  echo "ERROR: $REPO_DIR already exists."
+if [[ "$#" -ne 1 ]];then
+  echo "Provide path where to install pfunit as a first parameter"
   exit 1
 fi
 
-git clone --recursive https://github.com/Goddard-Fortran-Ecosystem/pFUnit $REPO_DIR && cd $REPO_DIR
+mkdir -p "$1"
+REPO_DIR="$1/$PFUNIT_VERSION/pFUnit"
+
+git clone --recursive --branch $PFUNIT_VERSION https://github.com/Goddard-Fortran-Ecosystem/pFUnit "$REPO_DIR" && cd "$REPO_DIR"
 
 # This seems to be the last commit that works with GCC-7
 # Later commits fail with internal compiler error when compiling fArgParse submodule. 

--- a/dev_scripts/install_plumed.sh
+++ b/dev_scripts/install_plumed.sh
@@ -25,12 +25,12 @@ if [[ -d $PLUMED_DIR/$PLUMED_VERSION ]];then
   exit 1
 fi
 
-mkdir -p $PLUMED_DIR/$PLUMED_VERSION/src
-mkdir -p $PLUMED_DIR/$PLUMED_VERSION/pkg
+mkdir -p "$PLUMED_DIR/$PLUMED_VERSION/src"
+mkdir -p "$PLUMED_DIR/$PLUMED_VERSION/pkg"
 
-curl -L "$DOWNLOAD_URL" > $PLUMED_DIR/$PLUMED_VERSION/pkg/${TAR_FILE}
-cd $PLUMED_DIR/$PLUMED_VERSION/src && tar -xzf ../pkg/${TAR_FILE} 
-cd plumed-${PLUMED_VERSION}
+curl -L "$DOWNLOAD_URL" > "$PLUMED_DIR/$PLUMED_VERSION/pkg/${TAR_FILE}"
+cd "$PLUMED_DIR/$PLUMED_VERSION/src" && tar -xzf "../pkg/${TAR_FILE}"
+cd "plumed-${PLUMED_VERSION}"
 
 # To keep things simple, we don't compile with MPI support
 # We also disable the use of external BLAS and LAPACK
@@ -44,7 +44,7 @@ cd plumed-${PLUMED_VERSION}
   --disable-mpi --disable-xdrfile \
   --disable-external-lapack --disable-external-blas \
   --enable-static-patch --enable-shared \
-  --prefix=${INSTALL_DIR} 2>&1 |\
+  --prefix="${INSTALL_DIR}" 2>&1 |\
   tee configure.log
 
 make -j $NPROC 2>&1 | tee make.log

--- a/dev_scripts/install_tcpb.sh
+++ b/dev_scripts/install_tcpb.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 REPO_URL="https://github.com/mtzgroup/tcpb-cpp.git"
-REPO_DIR="$HOME/tcpb-cpp"
-if [[ "$#" -eq 1 && ! -z $1 ]];then
-   REPO_DIR=$1
+if [[ "$#" -ne 1 ]];then
+  echo "Provide path where to install pfunit as a first parameter"
+  exit 1
 fi
+REPO_DIR=$1
 
 if [[ -e $REPO_DIR ]];then
   echo "ERROR: $REPO_DIR already exists."

--- a/prek.toml
+++ b/prek.toml
@@ -32,7 +32,7 @@ rev = "v0.11.0"
 hooks = [
   {
     id = "shellcheck",
-    files = "dev_scripts/setup_vim.sh"
+    files = "dev_scripts/"
   }
 ]
 
@@ -54,7 +54,7 @@ hooks = [
     name = "Format Fortran code",
     language = "python",
     entry = "./autoformat.py",
-    files = ".[fF]90",
+    types = ["fortran"],
     pass_filenames = true,
     # This list must be in sync with .fprettify.rc
     exclude = "interfaces/DFTB-SOCKET-DEV/*|utils/analyze_movie.f90|random.F90|fftw3.F90|force_cp2k.F90|h2o_schwenke.f|h2o_cvrqd.f"


### PR DESCRIPTION
We've been pinning the pFUnit version to an old commit for GCC 7 support. But we no longer test GCC 7 so let's update to the latest official version. (this is also a pre-requisite for compilation on MacOS, see #219 )

Also fixed shellcheck linter violations in all scripts in `dev_scripts` directory.