### PR TITLE
MacOS compatibile interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Always test the installation by running the test suite:
 ```console
 $ make test
 ```
+Note that if you compile ABIN on ARM processors (e.g. Macbooks), you need to change the `FFLAGS` and `CXXFLAGS` in the generated `make.vars` to use `-O0` or `-O1` instead of the default `-O2`, otherwise some of the tests may fail due to numerics. 
+
 If you modify the source code and want to recompile,
 you should always clean up before the recompilation:
 

--- a/interfaces/OPENQP-LZ/r.openqp-lz
+++ b/interfaces/OPENQP-LZ/r.openqp-lz
@@ -3,6 +3,7 @@
 # OPEN-QP/Landau-Zener Surface Hopping Interface for ABIN
 # Created by K. Vosovicova, J. Janos
 # Set parameters in 'openqp.inp.template' file
+# The interface was tested for both Linux and MacOS. In case of modifications, please check the compatibility with both OS.
 
 cd "$(dirname "$0")" || exit 2
 
@@ -16,7 +17,7 @@ natom=$(wc -l < ../$geom)
 output=input$ibead.log
 template=openqp.inp.template
 
-sed "1i ${natom}\n" "../$geom" > $geom
+{ printf '%s\n\n' "$natom"; cat "../$geom"; } > "$geom"  # used instead of 'sed "1i ${natom}\n" "../$geom" > $geom' to avoid issues with sed on MacOS
 rm -f ../engrad.dat.$ibead
 
 # -------------- DETERMINING CURRENT STATE -----------------
@@ -33,22 +34,24 @@ read -t 1 -a ntriplet		# (not used)
 
 cp $template $input
 
+tmp=$(mktemp) # create a temporary file for intermediate processing since sed -i is not supported on MacOS
+
 if [[ $timestep -ne 0 ]]; then
-    sed -i '/^\[guess\]/,/^\[scf\]/c\
+    sed '/^\[guess\]/,/^\[scf\]/c\
 [guess]\
 type=json\
 file=input001.json\
 \
-[scf]' "$input"
+[scf]' "$input" > "$tmp" && mv "$tmp" "$input"
 fi
 
-sed -i "/^\[tdhf\]/,/^\[/ s/^nstate=.*/nstate=$nstate/" "$input"
+sed "/^\[tdhf\]/,/^\[/ s/^nstate=.*/nstate=$nstate/" "$input" > "$tmp" && mv "$tmp" "$input"
 
-sed -i "/^\[properties\]/,/^\[/ s/^grad=.*/grad=$tocalc/" "$input"
+sed "/^\[properties\]/,/^\[/ s/^grad=.*/grad=$tocalc/" "$input" > "$tmp" && mv "$tmp" "$input"
 
 # ---------------------- JOB LAUNCH ------------------------
 
-source SetEnvironment.sh OPENQ
+source SetEnvironment.sh OPENQP
 
 $OPENQPEXE $input &> output_file
 

--- a/interfaces/OPENQP-LZ/r.openqp-lz
+++ b/interfaces/OPENQP-LZ/r.openqp-lz
@@ -17,6 +17,16 @@ natom=$(wc -l < ../$geom)
 output=input$ibead.log
 template=openqp.inp.template
 
+
+if [[ -f ../SetEnvironment.sh ]]; then
+  # This is specific to Prague clusters
+  source ../SetEnvironment.sh OPENQP
+else
+  # We assume openqp is in PATH already. If not, add it here.
+  OPENQPEXE=openqp
+fi
+
+
 { printf '%s\n\n' "$natom"; cat "../$geom"; } > "$geom"  # used instead of 'sed "1i ${natom}\n" "../$geom" > $geom' to avoid issues with sed on MacOS
 rm -f ../engrad.dat.$ibead
 
@@ -51,7 +61,6 @@ sed "/^\[properties\]/,/^\[/ s/^grad=.*/grad=$tocalc/" "$input" > "$tmp" && mv "
 
 # ---------------------- JOB LAUNCH ------------------------
 
-source SetEnvironment.sh OPENQP
 
 $OPENQPEXE $input &> output_file
 


### PR DESCRIPTION
I tested that the current ORCA interface works on MacOS and adapted the OPENQP-LZ interface such that it also works on MacOS. Both interfaces were tested on the newest MacOS 26.5.1 and Linux at the same time. 

If we solve the prek issue and compilation with `-O2` (#239) , ABIN should now be fully compatible with MacOS. 