### PR TITLE
Temporarily skip unit tests on macos runner

### DIFF
--- a/.github/workflows/gfortran.yml
+++ b/.github/workflows/gfortran.yml
@@ -83,6 +83,7 @@ jobs:
         LDLIBS: ${{ env.ABIN_LDLIBS }}
 
     - name: Run Unit tests
+      if: startsWith(matrix.os, 'ubuntu')
       run: make unittest
 
     - name: Codecov upload unit tests


### PR DESCRIPTION
For some reason the unit tests on macos-26 runners started failing with a linker error. Let's skip them for now.

```
ld: file cannot be open()ed, errno=2 (No such file or directory)
path=/opt/homebrew/Cellar/gcc/15.2.0_1/lib/gcc/current/libgomp.dylib in
'/opt/homebrew/Cellar/gcc/15.2.0_1/lib/gcc/current/libgomp.dylib'
```