### PR TITLE
Remove shellcheck pre-commit hook

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -25,17 +25,6 @@ hooks = [
   }
 ]
 
-[[repos]]
-# shellcheck: A shell linter, https://www.shellcheck.net/
-repo = "https://github.com/koalaman/shellcheck-precommit"
-rev = "v0.11.0"
-hooks = [
-  {
-    id = "shellcheck",
-    files = "dev_scripts/"
-  }
-]
-
 # Verify Github workflows have correct syntax
 [[repos]]
 repo = "https://github.com/python-jsonschema/check-jsonschema"


### PR DESCRIPTION
Unfortunately, shellcheck (BASH linter) pre-commit hook requires Docker for installation, which many people will not have. Let's remove it for now. One can still [install shellcheck](https://github.com/koalaman/shellcheck#user-content-installing) using e.g. apt and run it manually.