### PR TITLE
egrep is deprecated, use grep -E instead

### DIFF
--- a/tests/REMD/test.sh
+++ b/tests/REMD/test.sh
@@ -23,7 +23,7 @@ else
   MPIRUN="$MPI_PATH/bin/mpirun"
 fi
 
-N_REPLICAS=$(egrep --only-matching 'nreplica\s*=\s*[0-9]' $ABININ | egrep -o [0-9])
+N_REPLICAS=$(grep -E --only-matching 'nreplica\s*=\s*[0-9]' $ABININ | grep -E -o [0-9])
 
 $MPIRUN -np $N_REPLICAS $ABINEXE -i $ABININ -v $ABINVEL > $ABINOUT
 $MPIRUN -np $N_REPLICAS $ABINEXE -i ${ABININ}2 > ${ABINOUT}2

--- a/tests/TERAPI-FAILS/test3.sh
+++ b/tests/TERAPI-FAILS/test3.sh
@@ -18,7 +18,7 @@ IDX=3
 ABININ=input.in$IDX
 ABINOUT=${ABINOUT}$IDX
 TCOUT=${TCOUT}$IDX
-N_TERA_SERVERS=$(egrep --only-matching 'nteraservers\s*=\s*[0-9]' $ABININ | egrep -o [0-9])
+N_TERA_SERVERS=$(grep -E --only-matching 'nteraservers\s*=\s*[0-9]' $ABININ | grep -E -o [0-9])
 
 MPIRUN="$MPIRUN -n 1"
 ABIN_CMD="$ABINEXE -i $ABININ -x $ABINGEOM"

--- a/tests/TERAPI-PIMD-PARALLEL/test.sh
+++ b/tests/TERAPI-PIMD-PARALLEL/test.sh
@@ -11,7 +11,7 @@ if ! clean_output_files $1; then
   exit 0
 fi
 
-N_TERA_SERVERS=$(egrep --only-matching 'nteraservers\s*=\s*[0-9]' $ABININ | egrep -o [0-9])
+N_TERA_SERVERS=$(grep -E --only-matching 'nteraservers\s*=\s*[0-9]' $ABININ | grep -E -o [0-9])
 
 # Exit early for OpenMPI build.
 check_for_openmpi

--- a/tests/TERAPI-PIMD/test.sh
+++ b/tests/TERAPI-PIMD/test.sh
@@ -11,7 +11,7 @@ if ! clean_output_files $1; then
   exit 0
 fi
 
-N_TERA_SERVERS=$(egrep --only-matching 'nteraservers\s*=\s*[0-9]' $ABININ | egrep -o [0-9])
+N_TERA_SERVERS=$(grep -E --only-matching 'nteraservers\s*=\s*[0-9]' $ABININ | grep -E -o [0-9])
 
 # Exit early for OpenMPI build.
 check_for_openmpi

--- a/tests/TERAPI-REMD/test.sh
+++ b/tests/TERAPI-REMD/test.sh
@@ -16,7 +16,7 @@ if ! clean_output_files $1; then
   exit 0
 fi
 
-N_TERA_SERVERS=$(egrep --only-matching 'nreplica\s*=\s*[0-9]' $ABININ | egrep -o [0-9])
+N_TERA_SERVERS=$(grep -E --only-matching 'nreplica\s*=\s*[0-9]' $ABININ | grep -E -o [0-9])
 
 # Exit early for OpenMPI build.
 check_for_openmpi

--- a/tests/test_tc_server_utils.sh
+++ b/tests/test_tc_server_utils.sh
@@ -136,13 +136,13 @@ check_running_processes() {
   MAX_ITER=100
   iter=1
   while true;do
-    running=$(ps -eo pid | egrep "$regex" | wc -l)
+    running=$(ps -eo pid | grep -E "$regex" | wc -l)
     if [[ $running -eq 0 ]];then
       break
     elif [[ $running -lt $num_jobs ]];then
       # Give the others time to finish 
       sleep 1.2
-      running=$(ps -eo pid | egrep "$regex" | wc -l)
+      running=$(ps -eo pid | grep -E "$regex" | wc -l)
       if [[ $running -ne 0 ]];then
         echo "One of the TC servers or ABIN died. Killing the rest."
 	#echo "Printing ABIN and TC server outputs for debugging."


### PR DESCRIPTION
On my Fedora 39 system (already a few years old), using egrep prints a deprecation warning

```
❯ bash -c "egrep cds README.md" 
egrep: warning: egrep is obsolescent; using grep -E
```